### PR TITLE
Feat: sweetAlert 설정

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,12 +9,7 @@ module.exports = {
     sourceType: 'module',
   },
   plugins: ['react', '@typescript-eslint'],
-  extends: [
-    'eslint:recommended',
-    'plugin:react/recommended',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended',
-  ],
+  extends: ['eslint:recommended', 'plugin:react/recommended', 'plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended'],
   env: {
     browser: true,
     es2021: true,
@@ -26,5 +21,11 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     'react/react-in-jsx-scope': 'off',
     'react/no-unescaped-entities': 'off',
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
   },
 };

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal-root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.3.0",
-    "styled-components": "^5.3.5"
+    "styled-components": "^5.3.5",
+    "sweetalert2": "^11.4.14"
   },
   "devDependencies": {
     "@honkhonk/vite-plugin-svgr": "^1.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,11 @@ import MultiRangeSlider from '@/components/base/MultiRangeSlider';
 import 'sweetalert2/dist/sweetalert2.css';
 import Swal from 'sweetalert2';
 import { swalConfig } from '@/lib/styles/swalStyles';
+import useToggle from './hooks/common/useToggle';
+import ModalTemplate from './components/Modal';
 
 function App() {
+  const [isToggle, onChangeToggle] = useToggle();
   const onClick = async () => {
     const { isConfirmed, isDismissed } = await swalConfirm();
     if (isConfirmed) console.log('isConfirmed: ', isConfirmed);
@@ -19,6 +22,21 @@ function App() {
   return (
     <ThemeProvider theme={{ palette }}>
       <div className="App">
+        <GlobalStyles />
+        <Button onClick={onChangeToggle}>모달</Button>
+        {isToggle && (
+          <ModalTemplate
+            width={512}
+            height={172}
+            onToggleModal={onChangeToggle}
+            bottonName="다음"
+            onClick={() => {
+              console.log('확인');
+            }}
+            title="탈퇴하면 저장한 모든 설문정보가 사라집니다."
+            text="🥺 정말 탈퇴하시겠어요?"
+          />
+        )}
         <GlobalStyles />
         <header>
           <p> size === 'medium', variant === 'default' </p>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,16 +5,22 @@ import ProgressBar from '@/components/base/ProgressBar';
 import { ThemeProvider } from 'styled-components';
 import { palette } from '@/lib/styles/palette';
 import MultiRangeSlider from '@/components/base/MultiRangeSlider';
+import 'sweetalert2/dist/sweetalert2.css';
+import Swal from 'sweetalert2';
+import { swalConfig } from '@/lib/styles/swalStyles';
 
 function App() {
-  const onClick = () => console.log('hi');
+  const onClick = async () => {
+    const { isConfirmed, isDismissed } = await swalConfirm();
+    if (isConfirmed) console.log('isConfirmed: ', isConfirmed);
+    if (isDismissed) console.log('isDismessed: ', isDismissed);
+  };
 
   return (
     <ThemeProvider theme={{ palette }}>
       <div className="App">
         <GlobalStyles />
         <header>
-          <Logo />
           <p> size === 'medium', variant === 'default' </p>
           <Button onClick={onClick}>인증번호로 보내기</Button>
           <p> props === 'boxShadow' </p>
@@ -46,14 +52,23 @@ function App() {
             max={210}
             defaultMin={160}
             defaultMax={180}
-            onChange={({ min, max }) =>
-              console.log(`min = ${min}, max = ${max}`)
-            }
+            onChange={({ min, max }) => console.log(`min = ${min}, max = ${max}`)}
           />
         </header>
       </div>
     </ThemeProvider>
   );
 }
+
+const swalConfirm = () =>
+  Swal.fire({
+    title: '탈퇴하면 저장한 모든 설문정보가 사라집니다.',
+    // title: '국내 위치 설문 후 국내매칭을 이용하실 수 있습니다.',
+    // title: '다시 매칭하시겠습니까?',
+    text: '🥺 정말 탈퇴하시겠어요?',
+    // text: '지금 설문하시겠습니까?',
+    // text: '예전 설문 내용을 토대로 다시 매칭해드립니다.',
+    ...swalConfig,
+  });
 
 export default App;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,141 @@
+import { palette } from '@/lib/styles/palette';
+import transitions from '@/lib/styles/transitions';
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { Button } from './base';
+import ModalPortal from './ModalPortal';
+
+interface IModalInnerStyled {
+  width: number;
+  height: number;
+}
+
+interface IModalInnerProps extends IModalInnerStyled {
+  isClose: boolean;
+}
+
+interface ModalTemplateProps extends IModalInnerStyled {
+  title: string;
+  text: string;
+  /**
+   * 확인 버튼의 이름, 취소 버튼은 이름 고정.
+   */
+  bottonName: string;
+  onToggleModal: () => void;
+  /**
+   * 확인 버튼 누를시 실행할 함수
+   */
+  onClick: () => void;
+}
+
+function ModalTemplate({ width, height, title, text, bottonName, onToggleModal, onClick, ...rest }: ModalTemplateProps) {
+  const [isClose, setIsClose] = useState(false);
+  // modal 닫기전 시간 지연시켜 애니매이션 보게하기 위함
+  const onCloseModal = () => {
+    setIsClose(true);
+  };
+  useEffect(() => {
+    if (isClose) {
+      setTimeout(() => onToggleModal(), 150);
+    }
+  }, [isClose]);
+
+  return (
+    <ModalPortal>
+      <ModalTemplateBlock onMouseDown={onToggleModal} {...rest}>
+        <ModalInner width={width} height={height} onMouseDown={(e) => e.stopPropagation()} isClose={isClose}>
+          <ModalTitle>{title}</ModalTitle>
+          <ModalText>{text}</ModalText>
+          <ModalBtnBox>
+            <ModalButton variant="gray" onClick={onCloseModal}>
+              취소
+            </ModalButton>
+            <ModalButton
+              width={210}
+              onClick={() => {
+                onClick();
+                onCloseModal();
+              }}
+            >
+              {bottonName}
+            </ModalButton>
+          </ModalBtnBox>
+        </ModalInner>
+        <ModalBackground />
+      </ModalTemplateBlock>
+    </ModalPortal>
+  );
+}
+
+const ModalTemplateBlock = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  z-index: 9999;
+`;
+
+const ModalInner = styled.div<IModalInnerProps>`
+  display: flex;
+  flex-direction: column;
+  align-self: center;
+  position: absolute;
+  z-index: 9999;
+  background-color: white;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  margin: auto;
+  width: ${({ width }) => width}px;
+  height: ${({ height }) => height}px;
+  border-radius: 4px;
+  animation: ${({ isClose }) => (isClose ? transitions.popOut : transitions.popIn)} 0.2s ease-in-out;
+`;
+
+const ModalTitle = styled.div`
+  font-size: 1.3rem;
+  padding-top: 1.3rem;
+  line-height: 1.7rem;
+  text-align: center;
+  font-weight: 600;
+  color: #545454;
+`;
+
+const ModalText = styled.div`
+  line-height: 1.7rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.125em;
+  flex: 1 1 35%;
+  color: #575757;
+  text-align: center;
+`;
+
+const ModalBtnBox = styled.div`
+  flex: 1 1 25%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  margin-top: 10px;
+`;
+
+const ModalButton = styled(Button)`
+  margin: 5px 0 5px 5px;
+`;
+
+const ModalBackground = styled.div`
+  display: block;
+  width: 100%;
+  height: 100%;
+  background-color: ${palette.grayDarker};
+  position: absolute;
+  left: 0;
+  top: 0;
+  opacity: 0.4;
+`;
+
+export default ModalTemplate;

--- a/src/components/ModalPortal.ts
+++ b/src/components/ModalPortal.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { ReactNode, ReactPortal } from 'react';
 import reactDom from 'react-dom';
 

--- a/src/components/ModalPortal.ts
+++ b/src/components/ModalPortal.ts
@@ -1,0 +1,13 @@
+import { ReactNode, ReactPortal } from 'react';
+import reactDom from 'react-dom';
+
+interface ModalPortalProps {
+  children: ReactNode;
+}
+
+function ModalPortal({ children }: ModalPortalProps): ReactPortal {
+  const modalEl = document.getElementById('modal-root');
+  return reactDom.createPortal(children, modalEl!);
+}
+
+export default ModalPortal;

--- a/src/hooks/common/useToggle.ts
+++ b/src/hooks/common/useToggle.ts
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+
+type ReturnTypes = [boolean, () => void];
+
+export default function useToggle(initialValue = false): ReturnTypes {
+  const [value, setValue] = useState(initialValue);
+
+  const onToggle = () => {
+    setValue(!value);
+  };
+
+  return [value, onToggle];
+}

--- a/src/lib/styles/globalStyles.ts
+++ b/src/lib/styles/globalStyles.ts
@@ -1,4 +1,5 @@
 import { createGlobalStyle } from 'styled-components';
+import { palette } from './palette';
 
 const GlobalStyles = createGlobalStyle`
 html,
@@ -151,6 +152,52 @@ button {
   cursor: pointer;
   padding: 0;
 }
+
+.swal2-container {
+    z-index: 10600 !important;
+  }
+
+  .swal2-actions {
+    width: 100%;
+  }
+
+  .swal2-popup {
+    padding: 0;
+    /* max-width: 300px; */
+  }
+
+  .swal2-title {
+    font-size: 1.3rem;
+    padding-top: 1.5rem;
+    line-height: 1.7rem !important;
+  }
+
+  .swal2-html-container {
+    /* margin: 1rem 4rem 0 !important; */
+    line-height: 1.7rem !important;
+  }
+
+  .swal2-confirm {
+    flex: 1 !important;
+    background-color: ${palette.primary} !important;
+    border-radius: 4px;
+
+    &:focus {
+      box-shadow: 0 0 0 3px ${palette.grayLight} !important;
+    }
+  }
+
+  .swal2-cancel {
+    flex: 1 !important;
+    margin-right: 0 !important;
+    border-radius: 4px;
+    color: black !important;
+    background-color: ${palette.white} !important;
+
+    &:focus {
+      box-shadow: 0 0 0 3px ${palette.grayLight} !important;
+    }
+  }
 `;
 
 export default GlobalStyles;

--- a/src/lib/styles/swalStyles.ts
+++ b/src/lib/styles/swalStyles.ts
@@ -1,0 +1,7 @@
+export const swalConfig = {
+  showCancelButton: true,
+  showConfirmButton: true,
+  confirmButtonText: '확인',
+  cancelButtonText: '취소',
+  reverseButtons: true,
+};

--- a/src/lib/styles/transitions.ts
+++ b/src/lib/styles/transitions.ts
@@ -1,0 +1,32 @@
+import { keyframes } from 'styled-components';
+
+const fadeIn = keyframes`
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+`;
+
+const pop = keyframes`
+  50% {
+    -webkit-transform: scale(1.2);
+    transform: scale(1.2);
+  }
+  60% {
+    -webkit-transform: scale(1.1);
+    transform: scale(1.1);
+  }
+  60% {
+    -webkit-transform: scale(1.2);
+    transform: scale(1.2);
+  }
+`;
+
+const transitions = {
+  fadeIn,
+  pop,
+};
+
+export default transitions;

--- a/src/lib/styles/transitions.ts
+++ b/src/lib/styles/transitions.ts
@@ -9,7 +9,7 @@ const fadeIn = keyframes`
   }
 `;
 
-const pop = keyframes`
+const popIn = keyframes`
   50% {
     -webkit-transform: scale(1.2);
     transform: scale(1.2);
@@ -24,9 +24,17 @@ const pop = keyframes`
   }
 `;
 
+const popOut = keyframes`
+  100% {
+    -webkit-transform: scale(0.5);
+    transform: scale(0.5);
+  }
+`;
+
 const transitions = {
   fadeIn,
-  pop,
+  popIn,
+  popOut,
 };
 
 export default transitions;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2405,6 +2405,11 @@ svg-parser@^2.0.2:
   resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
   integrity sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==
 
+sweetalert2@^11.4.14:
+  version "11.4.14"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-11.4.14.tgz#b7c7efbf6672aa56696ba68d7ac141798b961525"
+  integrity sha512-Dh4XqfUSpCwhRsGM5zZFbtBRHujjcaf98DjVKXEs0ER4E/Zao0OtDHZRRQqvT9xxY7RA8WsiZ6FHJbyW+BBbDw==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"


### PR DESCRIPTION
- Closes #10 

## 🧑‍💻 PR 내용  
- sweetAlert2 패키지를 설치하고 기본 스타일을 적용했습니다.

### 사용법
1. 필요한 컴포넌트에서 아래 두개 import 합니다.
```ts
import Swal from 'sweetalert2';
import { swalConfig } from '@/lib/styles/swalStyles';
```

2.  필요한 곳에서 Swal 함수를 만들고 호출합니다. 기본 스타일을 적용하려면 swalConfig를 뿌립니다.
3.  기본 버튼 순서는 `취소 -> 확인`인데 순서를 바꾸고 싶을 땐 `reverseButtons: false`를 추가로 적용합니다.
```ts
const swalConfirm = () =>
  Swal.fire({
    title: '국내 위치 설문 후 국내매칭을 이용하실 수 있습니다.',
    text: '지금 설문하시겠습니까?',
    ...swalConfig,
  });
```

⚠️ width값 같은 건 최종 디자인 굳혀지면 적용할 예정입니다!
<!-- 수정/추가한 내용을 적어주세요. -->

## 📸 스크린샷
![image](https://user-images.githubusercontent.com/68528752/169685512-906bbe27-7ebd-4ce1-8912-0de8ee181b6a.png)

<!-- 스크린샷을 첨부해주세요. -->

