### PR TITLE
refactor: 버튼 타입 오류 수정, 시안 반영

### DIFF
--- a/src/components/base/Button/Button.tsx
+++ b/src/components/base/Button/Button.tsx
@@ -114,7 +114,8 @@ const ButtonBlock = styled.button<ButtonBlockProps>`
     `}
 `;
 
-type ButtonSizeBuilder = Record<string, string | number | undefined>;
+// type ButtonSizeBuilder = Record<string, string | number | undefined>;
+type ButtonSizeBuilder = Pick<ButtonBlockProps, 'height' | 'fontSize' | 'fontWeight'>;
 
 const buttonSizeBuilder = ({ height, fontSize, fontWeight }: ButtonSizeBuilder) => css`
   height: ${height}px;
@@ -126,13 +127,11 @@ const sizes = ({ fontSize, fontWeight, height }: Pick<ButtonProps, 'fontWeight' 
   small: buttonSizeBuilder({
     height: height ?? 38,
     fontSize: fontSize ?? 12,
-    lineHeight: 1.5,
     fontWeight: fontWeight ?? 600,
   }),
   medium: buttonSizeBuilder({
     height: height ?? 48,
     fontSize: fontSize ?? 14,
-    lineHeight: 1.2142857143,
     fontWeight: fontWeight ?? 700,
   }),
 });

--- a/src/components/base/Button/Button.tsx
+++ b/src/components/base/Button/Button.tsx
@@ -3,9 +3,6 @@ import styled, { css } from 'styled-components';
 import { palette } from '@/lib/styles/palette';
 
 export type ButtonSizes = 'small' | 'medium';
-/*
-  medium: 이전, 다음 버튼과 크기는 같은데 font-size가 14로 다름
-*/
 export type ButtonVariants = 'default' | 'gray' | 'grayBlack';
 export type ButtonColors = 'white' | 'gray' | 'black';
 
@@ -21,6 +18,7 @@ export interface ButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement
   fullWidth?: boolean;
   width?: number;
   height?: 38 | 48 | 70 | 100;
+  active?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
@@ -37,6 +35,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       width,
       height,
       fontWeight,
+      active = false,
       ...others
     },
     ref,
@@ -54,6 +53,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         fullWidth={fullWidth}
         width={width}
         height={height}
+        active={active}
         {...others}
       >
         {children}
@@ -78,30 +78,35 @@ const ButtonBlock = styled.button<ButtonBlockProps>`
   transition: background-color 300ms;
   cursor: pointer;
 
+  ${({ size, fontWeight, fontSize, height }) => sizes({ fontSize, fontWeight, height })[size ?? 'small']};
+  ${(props) => getVariant(props.variant ?? 'default')};
+
   ${(props) =>
     props.fullWidth &&
-    !props.width &&
     css`
       width: 100%;
-      min-width: 100%;
       max-width: 100%;
     `}
 
   ${(props) =>
-    !props.fullWidth &&
     props.width &&
     css`
       width: ${props.width}px;
     `}
-  
 
-  ${({ size, fontWeight, fontSize, height }) => sizes({ fontSize, fontWeight, height })[size ?? 'small']};
-  ${(props) => getVariant(props.variant ?? 'default')};
+  ${(props) =>
+    props.active &&
+    css`
+      background-color: ${palette.primary};
+      color: ${palette.white};
+    `}
+
   ${(props) =>
     props.boxShadow &&
     css`
       box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
     `};
+
   ${(props) =>
     props.disabled &&
     css`
@@ -173,13 +178,9 @@ ${variant === 'grayBlack' &&
     }
   `}
 
-  /* FIXME: hover, focus, active 될 때 각각 어떻게 될지 */
+  /* FIXME: hover, focus 될 때 각각 어떻게 될지 */
   &:focus {
-    background-color: ${palette.primary};
-    box-shadow: 0 0 1px 2px ${palette.gray};
-  }
-  &:active {
-    background-color: ${palette.gray};
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
   }
 `;
 

--- a/src/components/base/Button/Button.tsx
+++ b/src/components/base/Button/Button.tsx
@@ -1,34 +1,38 @@
 import React, { ButtonHTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
+import { palette } from '@/lib/styles/palette';
 
-export type ButtonSizes = 'medium' | 'large';
+export type ButtonSizes = 'small' | 'medium' | 'large';
+/*
+  medium: 이전, 다음 버튼과 크기는 같은데 font-size가 14로 다름
+*/
 export type ButtonVariants = 'default' | 'gray' | 'grayBlack';
 export type ButtonColors = 'white' | 'gray' | 'black';
 
-export interface ButtonProps
-  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'size' | 'color'> {
+export interface ButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'size' | 'color'> {
   children: React.ReactNode;
   size?: ButtonSizes;
   variant?: ButtonVariants;
   boxShadow?: boolean;
   disabled?: boolean;
   color?: ButtonColors;
-  fontWeight?: 400 | 700;
+  fontSize?: number;
+  fontWeight?: 300 | 400 | 600 | 700;
   fullWidth?: boolean;
   width?: number;
-  loading?: boolean;
+  height?: number;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       children,
-      size = 'medium',
+      size = 'small',
+      fontSize,
       variant = 'default',
       boxShadow = false,
       disabled = false,
       color = 'white',
-      loading = false,
       fullWidth = true,
       width,
       fontWeight = 400,
@@ -36,8 +40,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     },
     ref,
   ) => {
-    if (fullWidth && width)
-      console.error('width가 있으면 fullWidth는 falsy 해야함');
+    if (fullWidth && width) console.error('width가 있으면 fullWidth는 falsy 해야함');
 
     return (
       <ButtonBlock
@@ -47,6 +50,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         boxShadow={boxShadow}
         disabled={disabled}
         color={color}
+        fontSize={fontSize}
         fontWeight={fontWeight}
         fullWidth={fullWidth}
         width={width}
@@ -58,7 +62,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   },
 );
 
-type ButtonBlockProps = Omit<ButtonProps, 'children' | 'disabled' | 'loading'>;
+type ButtonBlockProps = Omit<ButtonProps, 'children'>;
 
 const ButtonBlock = styled.button<ButtonBlockProps>`
   display: inline-flex;
@@ -75,65 +79,67 @@ const ButtonBlock = styled.button<ButtonBlockProps>`
 
   ${(props) =>
     props.fullWidth &&
+    !props.width &&
     css`
       width: 100%;
       min-width: 100%;
       max-width: 100%;
     `}
 
-  ${({ fullWidth, width, size, fontWeight }) =>
-    sizes({ fullWidth, width, fontWeight })[size ?? 'medium']};
+  ${(props) =>
+    !props.fullWidth &&
+    props.width &&
+    css`
+      width: ${props.width}px;
+    `}
+  
+
+  ${({ size, fontWeight, fontSize }) => sizes({ fontSize, fontWeight })[size ?? 'small']};
   ${(props) => getVariant(props.variant ?? 'default')};
   ${(props) =>
     props.boxShadow &&
     css`
       box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
     `};
+  ${(props) =>
+    props.disabled &&
+    css`
+      /* TODO: disabled 시 백그라운드 처리 */
+      background-color: ${palette.grayDarker};
+      cursor: not-allowed;
+
+      &: hover {
+        background-color: ${palette.grayDarker};
+      }
+    `}
 `;
 
-type ButtonSizeBuilder = Record<string, number | boolean>;
+type ButtonSizeBuilder = Record<string, string | number | undefined>;
 
-const buttonSizeBuilder = ({
-  width,
-  height,
-  fontSize,
-  fontWeight,
-  fullWidth,
-}: ButtonSizeBuilder) => css`
-  height: ${height}px;
+const buttonSizeBuilder = ({ height, fontSize, fontWeight }: ButtonSizeBuilder) => css`
   font-size: ${fontSize}px;
+  height: ${height}px;
   font-weight: ${fontWeight};
-
-  ${fullWidth
-    ? css`
-        width: 100%;
-      `
-    : css`
-        width: ${width}px;
-        min-width: ${width}px;
-      `}
 `;
 
-const sizes = ({
-  fullWidth,
-  width,
-  fontWeight,
-}: Pick<ButtonProps, 'fullWidth' | 'width' | 'fontWeight'>) => ({
-  medium: buttonSizeBuilder({
+const sizes = ({ fontSize, fontWeight }: Pick<ButtonProps, 'fontWeight' | 'fontSize'>) => ({
+  small: buttonSizeBuilder({
     height: 38,
-    fontSize: 12,
+    fontSize: fontSize ?? 12,
     lineHeight: 1.5,
-    fontWeight: fontWeight ?? 400,
-    fullWidth: fullWidth ?? true,
-    width,
+    fontWeight: fontWeight ?? 600,
+  }),
+  medium: buttonSizeBuilder({
+    height: 48,
+    fontSize: fontSize ?? 14,
+    lineHeight: 1.2142857143,
+    fontWeight: fontWeight ?? 700,
   }),
   large: buttonSizeBuilder({
     height: 48,
-    fontSize: 18,
-    lineHeight: 1,
-    fontWeight: fontWeight ?? 400,
-    fullWidth: fullWidth ?? true,
-    width,
+    fontSize: fontSize ?? 16,
+    lineHeight: 1.125,
+    fontWeight: fontWeight ?? 700,
   }),
 });
 
@@ -142,48 +148,47 @@ const getVariant = (variant: ButtonVariants) => css`
 
   ${variant === 'default' &&
   css`
-    background-color: #49dac4;
-    ${getColor('white')};
+    background-color: ${palette.primary};
+    color: ${palette.white};
+    font-weight: 600;
+
+    &:hover {
+      background-color: ${palette.gray};
+    }
   `}
 
   ${variant === 'gray' &&
   css`
-    background-color: #e8e8e8;
-    ${getColor('gray')};
+    background-color: ${palette.grayLight};
+    color: rgba(0, 0, 0, 0.6);
+    font-weight: 300;
+
+    &:hover {
+      /* TODO: hover 색 처리 */
+    }
   `}
 
 ${variant === 'grayBlack' &&
   css`
-    background-color: #e8e8e8;
-    ${getColor('black')};
+    background-color: ${palette.grayLight};
+    color: ${palette.black};
+    font-weight: 400;
+
+    &:hover {
+      /* TODO: hover 색 처리 */
+    }
   `}
 
-  &:hover {
-    background-color: #f2f3f7;
-  }
+  /* FIXME: hover, focus, active 될 때 각각 어떻게 될지 */
   &:focus {
-    box-shadow: 0 0 1px 2px #e4e5ed;
+    background-color: ${palette.primary};
+    box-shadow: 0 0 1px 2px ${palette.gray};
   }
   &:active {
-    background-color: '#e4e5ed';
+    background-color: ${palette.gray};
   }
 `;
 
-const getColor = (color: ButtonColors) => css`
-  ${color === 'white' &&
-  css`
-    color: #fff;
-  `}
-
-  ${color === 'gray' &&
-  css`
-    color: rgba(0, 0, 0, 0.6);
-  `}
-
-	${color === 'black' &&
-  css`
-    color: #000;
-  `}
-`;
+Button.displayName = 'Button';
 
 export default Button;

--- a/src/components/base/Button/Button.tsx
+++ b/src/components/base/Button/Button.tsx
@@ -2,7 +2,7 @@ import React, { ButtonHTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
 import { palette } from '@/lib/styles/palette';
 
-export type ButtonSizes = 'small' | 'medium' | 'large';
+export type ButtonSizes = 'small' | 'medium';
 /*
   medium: 이전, 다음 버튼과 크기는 같은데 font-size가 14로 다름
 */
@@ -20,7 +20,7 @@ export interface ButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement
   fontWeight?: 300 | 400 | 600 | 700;
   fullWidth?: boolean;
   width?: number;
-  height?: number;
+  height?: 38 | 48 | 70 | 100;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
@@ -35,13 +35,12 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       color = 'white',
       fullWidth = true,
       width,
-      fontWeight = 400,
+      height,
+      fontWeight,
       ...others
     },
     ref,
   ) => {
-    if (fullWidth && width) console.error('width가 있으면 fullWidth는 falsy 해야함');
-
     return (
       <ButtonBlock
         ref={ref}
@@ -54,6 +53,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         fontWeight={fontWeight}
         fullWidth={fullWidth}
         width={width}
+        height={height}
         {...others}
       >
         {children}
@@ -94,7 +94,7 @@ const ButtonBlock = styled.button<ButtonBlockProps>`
     `}
   
 
-  ${({ size, fontWeight, fontSize }) => sizes({ fontSize, fontWeight })[size ?? 'small']};
+  ${({ size, fontWeight, fontSize, height }) => sizes({ fontSize, fontWeight, height })[size ?? 'small']};
   ${(props) => getVariant(props.variant ?? 'default')};
   ${(props) =>
     props.boxShadow &&
@@ -117,28 +117,22 @@ const ButtonBlock = styled.button<ButtonBlockProps>`
 type ButtonSizeBuilder = Record<string, string | number | undefined>;
 
 const buttonSizeBuilder = ({ height, fontSize, fontWeight }: ButtonSizeBuilder) => css`
-  font-size: ${fontSize}px;
   height: ${height}px;
+  font-size: ${fontSize}px;
   font-weight: ${fontWeight};
 `;
 
-const sizes = ({ fontSize, fontWeight }: Pick<ButtonProps, 'fontWeight' | 'fontSize'>) => ({
+const sizes = ({ fontSize, fontWeight, height }: Pick<ButtonProps, 'fontWeight' | 'fontSize' | 'height'>) => ({
   small: buttonSizeBuilder({
-    height: 38,
+    height: height ?? 38,
     fontSize: fontSize ?? 12,
     lineHeight: 1.5,
     fontWeight: fontWeight ?? 600,
   }),
   medium: buttonSizeBuilder({
-    height: 48,
+    height: height ?? 48,
     fontSize: fontSize ?? 14,
     lineHeight: 1.2142857143,
-    fontWeight: fontWeight ?? 700,
-  }),
-  large: buttonSizeBuilder({
-    height: 48,
-    fontSize: fontSize ?? 16,
-    lineHeight: 1.125,
     fontWeight: fontWeight ?? 700,
   }),
 });

--- a/src/lib/styles/palette.ts
+++ b/src/lib/styles/palette.ts
@@ -3,6 +3,6 @@ export const palette = {
   grayLight: '#E8E8E8',
   gray: '#e4e5ed',
   grayDarker: '#6F6F6F',
-  white: '#FFFFFF',
-  black: '#000000',
+  white: '#fff',
+  black: '#000',
 } as const;

--- a/src/lib/styles/palette.ts
+++ b/src/lib/styles/palette.ts
@@ -4,4 +4,5 @@ export const palette = {
   gray: '#e4e5ed',
   grayDarker: '#6F6F6F',
   white: '#FFFFFF',
+  black: '#000000',
 } as const;


### PR DESCRIPTION
## 🧑‍💻 PR 내용
- Closes #22

- Button size 'small', 'medium' 으로 축소
  - 다른 형태는 medium에서 fontSize, 혹은 height를 선언하여 변경하기 
  - 아래와 같은 카테고리 선택? 에서 사용될 듯 
![image](https://user-images.githubusercontent.com/68528752/170830798-b40f3619-a49e-45b4-88bf-a1e645f80406.png)
- palette black 추가
- disabled 속성 추가 (일단은 grayDarker로 색 설정)


## 📸 스크린샷
<img width="514" alt="image" src="https://user-images.githubusercontent.com/68528752/170831820-8f1ee1da-e4dd-4cb2-8ead-2cbd319de82e.png">

<!-- 스크린샷을 첨부해주세요. -->

