### PR TITLE
Chore: 기본 페이지들 라우터 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,56 +1,13 @@
-import Logo from './logo.svg?component';
-import { Button } from '@/components/base';
 import GlobalStyles from './lib/styles/globalStyles';
-import ProgressBar from '@/components/base/ProgressBar';
 import { ThemeProvider } from 'styled-components';
 import { palette } from '@/lib/styles/palette';
-import MultiRangeSlider from '@/components/base/MultiRangeSlider';
+import Routing from '@/router/Routing';
 
 function App() {
-  const onClick = () => console.log('hi');
-
   return (
     <ThemeProvider theme={{ palette }}>
-      <div className="App">
-        <GlobalStyles />
-        <header>
-          <Logo />
-          <p> size === 'medium', variant === 'default' </p>
-          <Button onClick={onClick}>인증번호로 보내기</Button>
-          <p> props === 'boxShadow' </p>
-          <Button boxShadow>인증번호로 보내기</Button>
-          <p> size === 'large' </p>
-          <Button size="large">인증번호로 보내기</Button>
-          <p> size === 'large' variant === 'gray' </p>
-          <Button size="large" variant="gray">
-            응답 수정하기
-          </Button>
-          <p> size === 'large' fontWeight = 700 </p>
-          <Button size="large" fontWeight={700}>
-            다음
-          </Button>
-          <p> size === 'large' variant === 'grayBlack' </p>
-          <Button size="large" variant="grayBlack">
-            다음
-          </Button>
-          <p> size === 'large' variant === 'grayBlack' width === 100 </p>
-          <Button size="large" variant="grayBlack" width={100}>
-            다음
-          </Button>
-          <p>프로그래스바</p>
-          <ProgressBar currStep={3} totalStep={10} />
-          <p>양방향 range input</p>
-          <div></div>
-          <MultiRangeSlider
-            min={130}
-            max={210}
-            defaultMin={160}
-            defaultMax={180}
-            onChange={({ min, max }) => console.log(`min = ${min}, max = ${max}`)}
-          />
-          테스트
-        </header>
-      </div>
+      <GlobalStyles />
+      <Routing />
     </ThemeProvider>
   );
 }

--- a/src/components/base/ProgressBar.tsx
+++ b/src/components/base/ProgressBar.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-interface ProgressBarProps {
+export interface ProgressBarProps {
   currStep: number;
   totalStep: number;
 }

--- a/src/components/base/ProgressBar.tsx
+++ b/src/components/base/ProgressBar.tsx
@@ -17,14 +17,13 @@ const ProgressBar = ({ currStep, totalStep }: ProgressBarProps) => {
 
 const NavigatorWrapper = styled.section`
   position: relative;
-  height: 89px;
   width: 100%;
-  margin: 24px 0;
+  margin-bottom: 43px;
 `;
 
 const Navigation = styled.div`
   width: 100%;
-  border: 6px solid ${({ theme }) => theme.palette.grayLight};
+  border: 3px solid ${({ theme }) => theme.palette.grayLight};
   border-radius: 20px;
 `;
 
@@ -32,9 +31,8 @@ const Progress = styled.span<ProgressBarProps>`
   position: absolute;
   top: 0;
   left: 0;
-  width: ${({ currStep, totalStep }) =>
-    `calc((100vw * ${currStep}) / ${totalStep})`};
-  border: 6px solid ${({ theme }) => theme.palette.primary};
+  width: ${({ currStep, totalStep }) => `calc((100vw * ${currStep}) / ${totalStep})`};
+  border: 3px solid ${({ theme }) => theme.palette.primary};
   border-radius: 20px;
   transition: all 0.5s ease-in-out;
 `;

--- a/src/components/base/Test.tsx
+++ b/src/components/base/Test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import Logo from '@/logo.svg?component';
+import { Button } from '@/components/base/index';
+import ProgressBar from '@/components/base/ProgressBar';
+import MultiRangeSlider from '@/components/base/MultiRangeSlider';
+
+const Test = () => {
+  const onClick = () => console.log('hi');
+  return (
+    <header>
+      <Logo />
+      <p> size === 'medium', variant === 'default' </p>
+      <Button onClick={onClick}>인증번호로 보내기</Button>
+      <p> props === 'boxShadow' </p>
+      <Button boxShadow>인증번호로 보내기</Button>
+      <p> size === 'large' </p>
+      <Button size="large">인증번호로 보내기</Button>
+      <p> size === 'large' variant === 'gray' </p>
+      <Button size="large" variant="gray">
+        응답 수정하기
+      </Button>
+      <p> size === 'large' fontWeight = 700 </p>
+      <Button size="large" fontWeight={700}>
+        다음
+      </Button>
+      <p> size === 'large' variant === 'grayBlack' </p>
+      <Button size="large" variant="grayBlack">
+        다음
+      </Button>
+      <p> size === 'large' variant === 'grayBlack' width === 100 </p>
+      <Button size="large" variant="grayBlack" width={100}>
+        다음
+      </Button>
+      <p>프로그래스바</p>
+      <ProgressBar currStep={3} totalStep={10} />
+      <p>양방향 range input</p>
+      <div></div>
+      <MultiRangeSlider
+        min={130}
+        max={210}
+        defaultMin={160}
+        defaultMax={180}
+        onChange={({ min, max }) => console.log(`min = ${min}, max = ${max}`)}
+      />
+      테스트
+    </header>
+  );
+};
+
+export default Test;

--- a/src/components/base/Test.tsx
+++ b/src/components/base/Test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Logo from '@/logo.svg?component';
 import { Button } from '@/components/base/index';
 import ProgressBar from '@/components/base/ProgressBar';

--- a/src/components/survey/SurveyTemplate.tsx
+++ b/src/components/survey/SurveyTemplate.tsx
@@ -1,0 +1,69 @@
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { ReactNode } from 'react';
+import { Button } from '@/components/base';
+import ProgressBar from '@/components/base/ProgressBar';
+
+interface SurveyTemplateProps {
+  children: ReactNode;
+  hasProgressBar?: boolean;
+  disableNext: boolean;
+}
+
+const SurveyTemplate = ({ children, hasProgressBar = true, disableNext }: SurveyTemplateProps) => {
+  return (
+    <>
+      <HeaderWrapper>
+        <Logo to="/">외딴썸</Logo>
+      </HeaderWrapper>
+      {children}
+      <NavigationWrapper>
+        {hasProgressBar && <ProgressBar currStep={1} totalStep={10} />}
+        <ButtonWrapper>
+          <Button size="large" variant="gray">
+            이전
+          </Button>
+          <Button
+            onClick={() => console.log('aa')}
+            size="large"
+            disabled={disableNext}
+            variant={disableNext ? 'gray' : 'default'}
+            fontWeight={disableNext ? 400 : 700}
+          >
+            다음
+          </Button>
+        </ButtonWrapper>
+      </NavigationWrapper>
+    </>
+  );
+};
+
+const HeaderWrapper = styled.header`
+  height: 56px;
+  padding: 20px 0;
+  margin-bottom: 26px;
+`;
+
+const Logo = styled(Link)`
+  font-family: SangjuGotgam, Pretendard Variable, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI',
+    'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 125%;
+  text-align: center;
+  color: rgba(0, 0, 0, 0.8);
+`;
+
+const NavigationWrapper = styled.div`
+  position: fixed;
+  width: calc(100% - 32px);
+  bottom: 38px;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  width: calc(50% - 4px);
+  gap: 8px;
+`;
+
+export default SurveyTemplate;

--- a/src/components/survey/SurveyTemplate.tsx
+++ b/src/components/survey/SurveyTemplate.tsx
@@ -2,15 +2,15 @@ import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { ReactNode } from 'react';
 import { Button } from '@/components/base';
-import ProgressBar from '@/components/base/ProgressBar';
+import ProgressBar, { ProgressBarProps } from '@/components/base/ProgressBar';
 
-interface SurveyTemplateProps {
+interface SurveyTemplateProps extends Partial<ProgressBarProps> {
   children: ReactNode;
   hasProgressBar?: boolean;
   disableNext: boolean;
 }
 
-const SurveyTemplate = ({ children, hasProgressBar = true, disableNext }: SurveyTemplateProps) => {
+const SurveyTemplate = ({ children, hasProgressBar = true, disableNext, currStep = 1, totalStep = 1 }: SurveyTemplateProps) => {
   return (
     <>
       <HeaderWrapper>
@@ -18,7 +18,7 @@ const SurveyTemplate = ({ children, hasProgressBar = true, disableNext }: Survey
       </HeaderWrapper>
       {children}
       <NavigationWrapper>
-        {hasProgressBar && <ProgressBar currStep={1} totalStep={10} />}
+        {hasProgressBar && <ProgressBar currStep={currStep} totalStep={totalStep} />}
         <ButtonWrapper>
           <Button size="large" variant="gray">
             이전

--- a/src/lib/styles/globalStyles.ts
+++ b/src/lib/styles/globalStyles.ts
@@ -1,158 +1,168 @@
 import { createGlobalStyle } from 'styled-components';
 
 const GlobalStyles = createGlobalStyle`
-html,
-body,
-#root {
-  height: 100%;
-  font-family: Pretendard Variable, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: auto;
-  font-size: 16px;
-}
-* {
-  box-sizing: border-box;
-  margin: 0;
-}
-a {
-  color: inherit;
-  text-decoration: none;
-}
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-textarea,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-input,
-button,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  vertical-align: baseline;
-}
-/* HTML5 display-role reset for older browsers */
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
-}
-body {
-  line-height: 1;
-  margin: 0;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-ol,
-ul {
-  list-style: none;
-}
-blockquote,
-q {
-  quotes: none;
-}
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
-}
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-button {
-  border: 0 none;
-  background-color: transparent;
-  cursor: pointer;
-  padding: 0;
-}
+  @font-face {
+    font-family: 'SangjuGotgam';
+    font-weight: normal;
+    font-style: normal;
+    src: url('https://cdn.jsdelivr.net/gh/webfontworld/sangju/SangjuGotgam.eot');
+    src: url('https://cdn.jsdelivr.net/gh/webfontworld/sangju/SangjuGotgam.eot?#iefix') format('embedded-opentype'),
+    url('https://cdn.jsdelivr.net/gh/webfontworld/sangju/SangjuGotgam.woff2') format('woff2'),
+    url('https://cdn.jsdelivr.net/gh/webfontworld/sangju/SangjuGotgam.woff') format('woff'),
+    url('https://cdn.jsdelivr.net/gh/webfontworld/sangju/SangjuGotgam.ttf') format("truetype");
+    font-display: swap;
+  }
+  html,
+  body,
+  #root {
+    height: 100%;
+    font-family: Pretendard Variable, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: auto;
+    font-size: 16px;
+  }
+  * {
+    box-sizing: border-box;
+    margin: 0;
+  }
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+  html,
+  body,
+  div,
+  span,
+  applet,
+  object,
+  iframe,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  blockquote,
+  pre,
+  a,
+  abbr,
+  acronym,
+  address,
+  big,
+  cite,
+  code,
+  del,
+  dfn,
+  em,
+  img,
+  ins,
+  kbd,
+  q,
+  s,
+  samp,
+  small,
+  strike,
+  strong,
+  sub,
+  sup,
+  tt,
+  var,
+  b,
+  u,
+  i,
+  center,
+  dl,
+  dt,
+  dd,
+  ol,
+  ul,
+  li,
+  fieldset,
+  form,
+  label,
+  legend,
+  table,
+  textarea,
+  caption,
+  tbody,
+  tfoot,
+  thead,
+  tr,
+  th,
+  td,
+  article,
+  aside,
+  canvas,
+  details,
+  embed,
+  figure,
+  figcaption,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  output,
+  ruby,
+  section,
+  summary,
+  time,
+  mark,
+  audio,
+  input,
+  button,
+  video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    vertical-align: baseline;
+  }
+  /* HTML5 display-role reset for older browsers */
+  article,
+  aside,
+  details,
+  figcaption,
+  figure,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  section {
+    display: block;
+  }
+  body {
+    line-height: 1;
+    margin: 0;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  ol,
+  ul {
+    list-style: none;
+  }
+  blockquote,
+  q {
+    quotes: none;
+  }
+  blockquote:before,
+  blockquote:after,
+  q:before,
+  q:after {
+    content: "";
+  }
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+  button {
+    border: 0 none;
+    background-color: transparent;
+    cursor: pointer;
+    padding: 0;
+  }
 `;
 
 export default GlobalStyles;

--- a/src/pages/AuthMail.tsx
+++ b/src/pages/AuthMail.tsx
@@ -1,0 +1,5 @@
+const AuthMail = () => {
+  return <div>AuthMail</div>;
+};
+
+export default AuthMail;

--- a/src/pages/AuthMail.tsx
+++ b/src/pages/AuthMail.tsx
@@ -1,5 +1,15 @@
+import SurveyTemplate from '@/components/survey/SurveyTemplate';
+import { Button } from '@/components/base';
+import { useState } from 'react';
+
 const AuthMail = () => {
-  return <div>AuthMail</div>;
+  const [canMoveNext, setCanMoveNext] = useState(true);
+
+  return (
+    <SurveyTemplate disableNext={canMoveNext} hasProgressBar={false}>
+      <Button onClick={() => setCanMoveNext((prev) => !prev)}>클릭</Button>
+    </SurveyTemplate>
+  );
 };
 
 export default AuthMail;

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,0 +1,22 @@
+import { Link } from 'react-router-dom';
+
+const Landing = () => {
+  return (
+    <div>
+      Landing
+      <ul>
+        <li>
+          <Link to="/component">- 예시 컴포넌트</Link>
+        </li>
+        <li>
+          <Link to="/auth-mail">- auth-mail</Link>
+        </li>
+        <li>
+          <Link to="/survey/1">- Survey</Link>
+        </li>
+      </ul>
+    </div>
+  );
+};
+
+export default Landing;

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 
 const Landing = () => {
   return (
+    /* 실제 랜딩페이지 작업 시에는 아래 내용 삭제해 주세요! */
     <div>
       Landing
       <ul>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const NotFound = () => {
+  return <div>NotFound</div>;
+};
+
+export default NotFound;

--- a/src/pages/Survey.tsx
+++ b/src/pages/Survey.tsx
@@ -1,0 +1,5 @@
+const Survey = () => {
+  return <div>Survey</div>;
+};
+
+export default Survey;

--- a/src/pages/Survey.tsx
+++ b/src/pages/Survey.tsx
@@ -7,7 +7,7 @@ const Survey = () => {
   const [canMoveNext, setCanMoveNext] = useState(true);
 
   return (
-    <SurveyTemplate disableNext={canMoveNext}>
+    <SurveyTemplate disableNext={canMoveNext} currStep={3} totalStep={10}>
       <Title>
         신원 확인을 위해 <br />
         학교 메일로 인증해주세요.

--- a/src/pages/Survey.tsx
+++ b/src/pages/Survey.tsx
@@ -1,5 +1,28 @@
+import styled from 'styled-components';
+import SurveyTemplate from '@/components/survey/SurveyTemplate';
+import { useState } from 'react';
+import { Button } from '@/components/base';
+
 const Survey = () => {
-  return <div>Survey</div>;
+  const [canMoveNext, setCanMoveNext] = useState(true);
+
+  return (
+    <SurveyTemplate disableNext={canMoveNext}>
+      <Title>
+        신원 확인을 위해 <br />
+        학교 메일로 인증해주세요.
+      </Title>
+      <Button onClick={() => setCanMoveNext((prev) => !prev)}>클릭</Button>
+    </SurveyTemplate>
+  );
 };
+
+const Title = styled.h1`
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 30px;
+  letter-spacing: -0.02em;
+  color: rgba(0, 0, 0, 0.9);
+`;
 
 export default Survey;

--- a/src/router/Path.ts
+++ b/src/router/Path.ts
@@ -1,5 +1,8 @@
 enum Path {
   LandingPage = '/',
+  Component = '/component', // FIXME: 컴포넌트 모아두는 곳 (개발완료 후 삭제)
+  AuthMail = '/auth-mail',
+  Survey = '/survey/:surveyId',
 }
 
 export default Path;

--- a/src/router/Routing.tsx
+++ b/src/router/Routing.tsx
@@ -1,13 +1,23 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
-import Path from './Path';
+import { Route, Routes, BrowserRouter } from 'react-router-dom';
+import Path from '@/router/Path';
+import Landing from '@/pages/Landing';
+import Test from '@/components/base/Test';
+import AuthMail from '@/pages/AuthMail';
+import Survey from '@/pages/Survey';
+import NotFound from '@/pages/NotFound';
 
 function Routing() {
   return (
-    <Routes>
-      {/* <Route path="*" element={<NotFoundPage />} /> */}
-      {/* <Route path={Path.LandingPage} element={<LandingPage />} /> */}
-    </Routes>
+    <BrowserRouter>
+      <Routes>
+        <Route path={Path.LandingPage} element={<Landing />} />
+        <Route path={Path.Component} element={<Test />} />
+        <Route path={Path.AuthMail} element={<AuthMail />} />
+        <Route path={Path.Survey} element={<Survey />} />
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </BrowserRouter>
   );
 }
 

--- a/src/router/Routing.tsx
+++ b/src/router/Routing.tsx
@@ -6,19 +6,27 @@ import Test from '@/components/base/Test';
 import AuthMail from '@/pages/AuthMail';
 import Survey from '@/pages/Survey';
 import NotFound from '@/pages/NotFound';
+import styled from 'styled-components';
 
 function Routing() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path={Path.LandingPage} element={<Landing />} />
-        <Route path={Path.Component} element={<Test />} />
-        <Route path={Path.AuthMail} element={<AuthMail />} />
-        <Route path={Path.Survey} element={<Survey />} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
+      <Layout>
+        <Routes>
+          <Route path={Path.LandingPage} element={<Landing />} />
+          <Route path={Path.Component} element={<Test />} />
+          <Route path={Path.AuthMail} element={<AuthMail />} />
+          <Route path={Path.Survey} element={<Survey />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </Layout>
     </BrowserRouter>
   );
 }
+
+const Layout = styled.main`
+  margin: 0 16px;
+  height: 100%;
+`;
 
 export default Routing;


### PR DESCRIPTION
## 🧑‍💻 PR 내용

<!-- 수정/추가한 내용을 적어주세요. -->
- 기본 페이지들 라우터 추가하였습니다. 
- 예시 컴포넌트들은 `/component`로 접근되도록 변경했습니다!


## 📸 스크린샷

<!-- 스크린샷을 첨부해주세요. -->
<img width="401" alt="Screen Shot 2022-05-29 at 0 12 29" src="https://user-images.githubusercontent.com/30427711/170831349-8474027a-ec8a-4ea0-93de-9443a8062c88.png">

