### PR TITLE
Design: 인증 / 설문 레이아웃 

### DIFF
--- a/src/components/base/ProgressBar.tsx
+++ b/src/components/base/ProgressBar.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-interface ProgressBarProps {
+export interface ProgressBarProps {
   currStep: number;
   totalStep: number;
 }

--- a/src/components/base/ProgressBar.tsx
+++ b/src/components/base/ProgressBar.tsx
@@ -17,14 +17,13 @@ const ProgressBar = ({ currStep, totalStep }: ProgressBarProps) => {
 
 const NavigatorWrapper = styled.section`
   position: relative;
-  height: 89px;
   width: 100%;
-  margin: 24px 0;
+  margin-bottom: 43px;
 `;
 
 const Navigation = styled.div`
   width: 100%;
-  border: 6px solid ${({ theme }) => theme.palette.grayLight};
+  border: 3px solid ${({ theme }) => theme.palette.grayLight};
   border-radius: 20px;
 `;
 
@@ -32,9 +31,8 @@ const Progress = styled.span<ProgressBarProps>`
   position: absolute;
   top: 0;
   left: 0;
-  width: ${({ currStep, totalStep }) =>
-    `calc((100vw * ${currStep}) / ${totalStep})`};
-  border: 6px solid ${({ theme }) => theme.palette.primary};
+  width: ${({ currStep, totalStep }) => `calc((100vw * ${currStep}) / ${totalStep})`};
+  border: 3px solid ${({ theme }) => theme.palette.primary};
   border-radius: 20px;
   transition: all 0.5s ease-in-out;
 `;

--- a/src/components/base/Test.tsx
+++ b/src/components/base/Test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Logo from '@/logo.svg?component';
 import { Button } from '@/components/base/index';
 import ProgressBar from '@/components/base/ProgressBar';

--- a/src/components/survey/SurveyTemplate.tsx
+++ b/src/components/survey/SurveyTemplate.tsx
@@ -1,0 +1,69 @@
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { ReactNode } from 'react';
+import { Button } from '@/components/base';
+import ProgressBar from '@/components/base/ProgressBar';
+
+interface SurveyTemplateProps {
+  children: ReactNode;
+  hasProgressBar?: boolean;
+  disableNext: boolean;
+}
+
+const SurveyTemplate = ({ children, hasProgressBar = true, disableNext }: SurveyTemplateProps) => {
+  return (
+    <>
+      <HeaderWrapper>
+        <Logo to="/">외딴썸</Logo>
+      </HeaderWrapper>
+      {children}
+      <NavigationWrapper>
+        {hasProgressBar && <ProgressBar currStep={1} totalStep={10} />}
+        <ButtonWrapper>
+          <Button size="large" variant="gray">
+            이전
+          </Button>
+          <Button
+            onClick={() => console.log('aa')}
+            size="large"
+            disabled={disableNext}
+            variant={disableNext ? 'gray' : 'default'}
+            fontWeight={disableNext ? 400 : 700}
+          >
+            다음
+          </Button>
+        </ButtonWrapper>
+      </NavigationWrapper>
+    </>
+  );
+};
+
+const HeaderWrapper = styled.header`
+  height: 56px;
+  padding: 20px 0;
+  margin-bottom: 26px;
+`;
+
+const Logo = styled(Link)`
+  font-family: SangjuGotgam, Pretendard Variable, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI',
+    'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 125%;
+  text-align: center;
+  color: rgba(0, 0, 0, 0.8);
+`;
+
+const NavigationWrapper = styled.div`
+  position: fixed;
+  width: calc(100% - 32px);
+  bottom: 38px;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  width: calc(50% - 4px);
+  gap: 8px;
+`;
+
+export default SurveyTemplate;

--- a/src/components/survey/SurveyTemplate.tsx
+++ b/src/components/survey/SurveyTemplate.tsx
@@ -2,15 +2,15 @@ import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { ReactNode } from 'react';
 import { Button } from '@/components/base';
-import ProgressBar from '@/components/base/ProgressBar';
+import ProgressBar, { ProgressBarProps } from '@/components/base/ProgressBar';
 
-interface SurveyTemplateProps {
+interface SurveyTemplateProps extends Partial<ProgressBarProps> {
   children: ReactNode;
   hasProgressBar?: boolean;
   disableNext: boolean;
 }
 
-const SurveyTemplate = ({ children, hasProgressBar = true, disableNext }: SurveyTemplateProps) => {
+const SurveyTemplate = ({ children, hasProgressBar = true, disableNext, currStep = 1, totalStep = 1 }: SurveyTemplateProps) => {
   return (
     <>
       <HeaderWrapper>
@@ -18,7 +18,7 @@ const SurveyTemplate = ({ children, hasProgressBar = true, disableNext }: Survey
       </HeaderWrapper>
       {children}
       <NavigationWrapper>
-        {hasProgressBar && <ProgressBar currStep={1} totalStep={10} />}
+        {hasProgressBar && <ProgressBar currStep={currStep} totalStep={totalStep} />}
         <ButtonWrapper>
           <Button size="large" variant="gray">
             이전

--- a/src/lib/styles/globalStyles.ts
+++ b/src/lib/styles/globalStyles.ts
@@ -1,158 +1,168 @@
 import { createGlobalStyle } from 'styled-components';
 
 const GlobalStyles = createGlobalStyle`
-html,
-body,
-#root {
-  height: 100%;
-  font-family: Pretendard Variable, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: auto;
-  font-size: 16px;
-}
-* {
-  box-sizing: border-box;
-  margin: 0;
-}
-a {
-  color: inherit;
-  text-decoration: none;
-}
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-textarea,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-input,
-button,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  vertical-align: baseline;
-}
-/* HTML5 display-role reset for older browsers */
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
-}
-body {
-  line-height: 1;
-  margin: 0;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-ol,
-ul {
-  list-style: none;
-}
-blockquote,
-q {
-  quotes: none;
-}
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
-}
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-button {
-  border: 0 none;
-  background-color: transparent;
-  cursor: pointer;
-  padding: 0;
-}
+  @font-face {
+    font-family: 'SangjuGotgam';
+    font-weight: normal;
+    font-style: normal;
+    src: url('https://cdn.jsdelivr.net/gh/webfontworld/sangju/SangjuGotgam.eot');
+    src: url('https://cdn.jsdelivr.net/gh/webfontworld/sangju/SangjuGotgam.eot?#iefix') format('embedded-opentype'),
+    url('https://cdn.jsdelivr.net/gh/webfontworld/sangju/SangjuGotgam.woff2') format('woff2'),
+    url('https://cdn.jsdelivr.net/gh/webfontworld/sangju/SangjuGotgam.woff') format('woff'),
+    url('https://cdn.jsdelivr.net/gh/webfontworld/sangju/SangjuGotgam.ttf') format("truetype");
+    font-display: swap;
+  }
+  html,
+  body,
+  #root {
+    height: 100%;
+    font-family: Pretendard Variable, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: auto;
+    font-size: 16px;
+  }
+  * {
+    box-sizing: border-box;
+    margin: 0;
+  }
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+  html,
+  body,
+  div,
+  span,
+  applet,
+  object,
+  iframe,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  blockquote,
+  pre,
+  a,
+  abbr,
+  acronym,
+  address,
+  big,
+  cite,
+  code,
+  del,
+  dfn,
+  em,
+  img,
+  ins,
+  kbd,
+  q,
+  s,
+  samp,
+  small,
+  strike,
+  strong,
+  sub,
+  sup,
+  tt,
+  var,
+  b,
+  u,
+  i,
+  center,
+  dl,
+  dt,
+  dd,
+  ol,
+  ul,
+  li,
+  fieldset,
+  form,
+  label,
+  legend,
+  table,
+  textarea,
+  caption,
+  tbody,
+  tfoot,
+  thead,
+  tr,
+  th,
+  td,
+  article,
+  aside,
+  canvas,
+  details,
+  embed,
+  figure,
+  figcaption,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  output,
+  ruby,
+  section,
+  summary,
+  time,
+  mark,
+  audio,
+  input,
+  button,
+  video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    vertical-align: baseline;
+  }
+  /* HTML5 display-role reset for older browsers */
+  article,
+  aside,
+  details,
+  figcaption,
+  figure,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  section {
+    display: block;
+  }
+  body {
+    line-height: 1;
+    margin: 0;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  ol,
+  ul {
+    list-style: none;
+  }
+  blockquote,
+  q {
+    quotes: none;
+  }
+  blockquote:before,
+  blockquote:after,
+  q:before,
+  q:after {
+    content: "";
+  }
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+  button {
+    border: 0 none;
+    background-color: transparent;
+    cursor: pointer;
+    padding: 0;
+  }
 `;
 
 export default GlobalStyles;

--- a/src/pages/AuthMail.tsx
+++ b/src/pages/AuthMail.tsx
@@ -1,5 +1,15 @@
+import SurveyTemplate from '@/components/survey/SurveyTemplate';
+import { Button } from '@/components/base';
+import { useState } from 'react';
+
 const AuthMail = () => {
-  return <div>AuthMail</div>;
+  const [canMoveNext, setCanMoveNext] = useState(true);
+
+  return (
+    <SurveyTemplate disableNext={canMoveNext} hasProgressBar={false}>
+      <Button onClick={() => setCanMoveNext((prev) => !prev)}>클릭</Button>
+    </SurveyTemplate>
+  );
 };
 
 export default AuthMail;

--- a/src/pages/Survey.tsx
+++ b/src/pages/Survey.tsx
@@ -7,7 +7,7 @@ const Survey = () => {
   const [canMoveNext, setCanMoveNext] = useState(true);
 
   return (
-    <SurveyTemplate disableNext={canMoveNext}>
+    <SurveyTemplate disableNext={canMoveNext} currStep={3} totalStep={10}>
       <Title>
         신원 확인을 위해 <br />
         학교 메일로 인증해주세요.

--- a/src/pages/Survey.tsx
+++ b/src/pages/Survey.tsx
@@ -1,5 +1,28 @@
+import styled from 'styled-components';
+import SurveyTemplate from '@/components/survey/SurveyTemplate';
+import { useState } from 'react';
+import { Button } from '@/components/base';
+
 const Survey = () => {
-  return <div>Survey</div>;
+  const [canMoveNext, setCanMoveNext] = useState(true);
+
+  return (
+    <SurveyTemplate disableNext={canMoveNext}>
+      <Title>
+        신원 확인을 위해 <br />
+        학교 메일로 인증해주세요.
+      </Title>
+      <Button onClick={() => setCanMoveNext((prev) => !prev)}>클릭</Button>
+    </SurveyTemplate>
+  );
 };
+
+const Title = styled.h1`
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 30px;
+  letter-spacing: -0.02em;
+  color: rgba(0, 0, 0, 0.9);
+`;
 
 export default Survey;

--- a/src/router/Routing.tsx
+++ b/src/router/Routing.tsx
@@ -6,19 +6,27 @@ import Test from '@/components/base/Test';
 import AuthMail from '@/pages/AuthMail';
 import Survey from '@/pages/Survey';
 import NotFound from '@/pages/NotFound';
+import styled from 'styled-components';
 
 function Routing() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path={Path.LandingPage} element={<Landing />} />
-        <Route path={Path.Component} element={<Test />} />
-        <Route path={Path.AuthMail} element={<AuthMail />} />
-        <Route path={Path.Survey} element={<Survey />} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
+      <Layout>
+        <Routes>
+          <Route path={Path.LandingPage} element={<Landing />} />
+          <Route path={Path.Component} element={<Test />} />
+          <Route path={Path.AuthMail} element={<AuthMail />} />
+          <Route path={Path.Survey} element={<Survey />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </Layout>
     </BrowserRouter>
   );
 }
+
+const Layout = styled.main`
+  margin: 0 16px;
+  height: 100%;
+`;
 
 export default Routing;


### PR DESCRIPTION
## 🧑‍💻 PR 내용

<!-- 수정/추가한 내용을 적어주세요. -->
- 설문/인증 페이지 레이아웃 템플릿 만들었습니다 !
- 전체 페이지 margin, height 을 줘서 감싸는 레이아웃도 추가했습니다

<img width="477" alt="Screen Shot 2022-05-29 at 15 42 03" src="https://user-images.githubusercontent.com/30427711/170855683-b456c7c1-bcc7-48f9-9fc6-dfee908a8902.png">

## 의견 

- 설문 페이지의 경우 페이지전략을 어떻게 가져갈지 좀더 고민이 필요할 것 같은데 어떻게 생각하시는지 궁금합니다. @Jeong-jeong @leejiho9898 
  1. /survey/:surveyId로 하나의 라우터 페이지를 가지고 내용만 바뀌게 하는 방식
  2. /survey 하위에 설문마다 라우터 페이지를 정해 두고 계속 페이지 이동하게 하는 방식

저는 설문이 많아서 2번이 덜 복잡해지지 않을까 싶기도 한데 1번도 컴포넌트를 잘 해두면 괜찮을것 같아서 고민이 되네요 🤔🤔

## 📸 스크린샷

<!-- 스크린샷을 첨부해주세요. -->

템플릿 안에 내용은 임의로 넣어둔것입니다!

| 설문(프로그래스바 있음)  | 인증 페이지(프로그래스바 없음)  |
|---|---|
| <img width="402" alt="Screen Shot 2022-05-29 at 15 33 52" src="https://user-images.githubusercontent.com/30427711/170855630-6aff3085-9fcb-46ad-93d1-e9680dc7249a.png">  | <img width="396" alt="Screen Shot 2022-05-29 at 15 33 42" src="https://user-images.githubusercontent.com/30427711/170855641-4e3767d8-59c7-4a65-9ee3-388c0aed6773.png"> |
|   |   |