### PR TITLE
Feat: Range input 레이아웃, 버그 수정

### DIFF
--- a/src/components/base/MultiRangeSlider.tsx
+++ b/src/components/base/MultiRangeSlider.tsx
@@ -7,167 +7,193 @@ export interface Ranges {
 }
 
 interface MultiRangeSliderProps extends Ranges {
-  defaultMin?: number;
-  defaultMax?: number;
   onChange?: (rangeValues: Ranges) => void;
 }
 
-const MultiRangeSlider = ({
-  min,
-  max,
-  defaultMin = min,
-  defaultMax = max,
-  onChange,
-}: MultiRangeSliderProps) => {
-  const [minValue, setMinVal] = useState(defaultMin);
-  const [maxValue, setMaxVal] = useState(defaultMax);
+const MultiRangeSlider = ({ min, max, onChange }: MultiRangeSliderProps) => {
+  const [minVal, setMinVal] = useState(min);
+  const [maxVal, setMaxVal] = useState(max);
   const minValRef = useRef<HTMLInputElement>(null);
   const maxValRef = useRef<HTMLInputElement>(null);
-  const leftRange = useRef<HTMLDivElement>(null);
-  const rightRange = useRef<HTMLDivElement>(null);
   const range = useRef<HTMLDivElement>(null);
+  const sign = useRef<HTMLSpanElement>(null);
 
-  const getPercent = useCallback(
-    (value: number) => Math.round(((value - min) / (max - min)) * 100),
+  const getPercent = useCallback((value: number) => Math.round(((value - min) / (max - min)) * 100), [min, max]);
+  const getMidValue = useCallback(
+    (midLevel: 1 | 2) => {
+      return min + Math.floor((max - min) / 3) * midLevel;
+    },
     [min, max],
   );
 
-  const handleRangeChange = (
-    event: ChangeEvent<HTMLInputElement>,
-    type: 'min' | 'max',
-  ) => {
-    const targetValue = type === 'min' ? maxValue - 1 : minValue + 1;
-    const value = Math.min(Number(event.target.value), targetValue);
+  const handleChangeRange = (event: ChangeEvent<HTMLInputElement>, type: 'min' | 'max') => {
+    const diffValue = type === 'min' ? maxVal - 1 : minVal + 1;
+    const value = Math[type](Number(event.target.value), diffValue);
     type === 'min' ? setMinVal(value) : setMaxVal(value);
     event.target.value = value.toString();
   };
 
   useEffect(() => {
     if (maxValRef.current) {
-      const minPercent = getPercent(minValue);
+      const minPercent = getPercent(minVal);
       const maxPercent = getPercent(Number(maxValRef.current.value));
 
-      if (leftRange.current) {
-        leftRange.current.style.left = `${minPercent}%`;
-      }
       if (range.current) {
         range.current.style.left = `${minPercent}%`;
         range.current.style.width = `${maxPercent - minPercent}%`;
       }
+      if (sign.current) {
+        sign.current.style.left = `calc(${minPercent}% - ${sign.current.clientWidth / 2}px${minPercent < 10 ? ' + 40px' : ''})`;
+      }
     }
-  }, [minValue, getPercent]);
+  }, [minVal, getPercent]);
 
   useEffect(() => {
     if (minValRef.current) {
       const minPercent = getPercent(Number(minValRef.current.value));
-      const maxPercent = getPercent(maxValue);
+      const maxPercent = getPercent(maxVal);
 
-      if (rightRange.current) {
-        rightRange.current.style.left = `${maxPercent}%`;
-      }
       if (range.current) {
         range.current.style.width = `${maxPercent - minPercent}%`;
       }
+      if (sign.current) {
+        sign.current.style.left = `calc(${maxPercent}% - ${sign.current.clientWidth / 2}px${maxPercent > 90 ? ' - 40px' : ''})`;
+      }
     }
-  }, [maxValue, getPercent]);
+  }, [maxVal, getPercent]);
 
   useEffect(() => {
-    onChange?.({ min: minValue, max: maxValue });
-  }, [minValue, maxValue, onChange]);
+    onChange?.({ min: minVal, max: maxVal });
+  }, [minVal, maxVal, onChange]);
 
   return (
-    <Slider>
+    <Container>
       <SliderInput
         type="range"
-        id="input-left"
         min={min}
         max={max}
-        value={minValue}
+        value={minVal}
         ref={minValRef}
-        onChange={(e) => handleRangeChange(e, 'min')}
-        zIndex={minValue > max - 100 ? 5 : 3}
+        onChange={(event) => handleChangeRange(event, 'min')}
+        zIndex={minVal > max - 100 ? 5 : 3}
       />
-      <SliderInput
-        type="range"
-        id="input-right"
-        min={min}
-        max={max}
-        value={maxValue}
-        ref={maxValRef}
-        onChange={(e) => handleRangeChange(e, 'max')}
-        zIndex={4}
-      />
+      <SliderInput type="range" min={min} max={max} value={maxVal} ref={maxValRef} onChange={(event) => handleChangeRange(event, 'max')} zIndex={4} />
+
       <TrackWrapper>
-        <Range ref={range}></Range>
-        <Thumb ref={leftRange}></Thumb>
-        <Thumb ref={rightRange}></Thumb>
+        <Track />
+        <Range ref={range} />
+        <LabelWrapper>
+          <Label>{min}</Label>
+          <Label>{getMidValue(1)}</Label>
+          <Label>{getMidValue(2)}</Label>
+          <Label>{max}</Label>
+        </LabelWrapper>
+        <SignWrapper>
+          <Sign ref={sign}>
+            {minVal} - {maxVal}
+          </Sign>
+        </SignWrapper>
       </TrackWrapper>
-    </Slider>
+    </Container>
   );
 };
 
-const Slider = styled.div`
-  height: 100%;
-  width: 100%;
+const Container = styled.div`
+  height: 50px;
   display: flex;
-  padding: 1.5rem;
   align-items: center;
   justify-content: center;
-  position: relative;
 `;
 
 const SliderInput = styled.input<{ zIndex: number }>`
-  width: calc(100% - 2rem);
-  top: 1rem;
-  left: 1rem;
-  position: absolute;
-  border: none;
   pointer-events: none;
+  position: absolute;
+  height: 0;
+  outline: none;
+  width: calc(100% - 2rem);
   z-index: ${({ zIndex }) => zIndex};
   appearance: none;
-  opacity: 0;
 
   &::-webkit-slider-thumb {
+    -webkit-appearance: none;
     position: relative;
     pointer-events: all;
     appearance: none;
     background-color: ${({ theme }) => theme.palette.primary};
-    width: 2.5rem;
-    height: 1.5rem;
+    width: 20px;
+    height: 20px;
     cursor: pointer;
-  }
-
-  &:first-child {
-    top: 1rem;
+    border: none;
+    border-radius: 50%;
+    margin-top: 4px;
   }
 `;
 
 const TrackWrapper = styled.div`
-  position: relative;
   width: 100%;
-  height: 0.5rem;
-  background-color: ${({ theme }) => theme.palette.grayLight};
-  border-radius: 0.5rem;
+  position: relative;
+`;
+
+const SignWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+const Sign = styled.span`
+  position: absolute;
+  bottom: 16px;
+  color: ${({ theme }) => theme.palette.white};
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 125%;
+  text-align: center;
+  background-color: ${({ theme }) => theme.palette.primary};
+  border-radius: 4px;
+  padding: 6px 8px;
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -7px;
+    margin: 0 auto;
+    width: 0;
+    height: 0;
+    border-top: 8px solid ${({ theme }) => theme.palette.primary};
+    border-left: 6px solid transparent;
+    border-right: 6px solid transparent;
+  }
+`;
+
+const Track = styled.div`
+  position: absolute;
+  border-radius: 3px;
+  height: 6px;
+  border: 3px solid ${({ theme }) => theme.palette.grayLight};
+  width: 100%;
+  z-index: 1;
 `;
 
 const Range = styled.div`
   position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  border-radius: 3px;
+  height: 6px;
+  z-index: 2;
   background-color: ${({ theme }) => theme.palette.primary};
-  border-radius: 0.5rem;
 `;
 
-const Thumb = styled.div`
+const LabelWrapper = styled.div`
   position: absolute;
-  top: 0;
-  transform: translateY(-0.25rem);
-  width: 1rem;
-  height: 1rem;
-  background-color: ${({ theme }) => theme.palette.primary};
-  border-radius: 50%;
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+`;
+
+const Label = styled.span`
+  color: ${({ theme }) => theme.palette.black};
+  font-size: 12px;
+  margin-top: 20px;
 `;
 
 export default MultiRangeSlider;

--- a/src/components/base/Test.tsx
+++ b/src/components/base/Test.tsx
@@ -52,14 +52,9 @@ const Test = () => {
         <p>프로그래스바</p>
         <ProgressBar currStep={3} totalStep={10} />
         <p>양방향 range input</p>
-        <div></div>
-        <MultiRangeSlider
-          min={130}
-          max={210}
-          defaultMin={160}
-          defaultMax={180}
-          onChange={({ min, max }) => console.log(`min = ${min}, max = ${max}`)}
-        />
+        <MultiRangeSlider min={20} max={35} onChange={({ min, max }) => console.log(`min = ${min}, max = ${max}`)} />
+        <div style={{ padding: '30px' }}></div>
+        <MultiRangeSlider min={120} max={210} onChange={({ min, max }) => console.log(`min = ${min}, max = ${max}`)} />
         테스트
       </header>
     </>


### PR DESCRIPTION
## 🧑‍💻 PR 내용

<!-- 수정/추가한 내용을 적어주세요. -->

- range input에 추가된 상하단 레이아웃 추가하였습니다
  - 주의점: 하단에 중간값을 2개를 넣어야 해서 max - min 계산값이 3으로 나누어떨어지는 것이 보다 보기 이쁩니다. 
<img width="361" alt="Screen Shot 2022-06-01 at 13 53 21" src="https://user-images.githubusercontent.com/30427711/171330408-b2d73b24-9389-4050-a2d5-fb5daf427c6f.png">

- defaultMin, defaultMax 제거하였습니다. (초기값은 모두 채워진 상태)
<img width="360" alt="Screen Shot 2022-06-01 at 13 50 07" src="https://user-images.githubusercontent.com/30427711/171330070-9fed0349-0cf2-4cb1-ba9a-5f18252d2156.png">

- 동작 오류 수정했습니다. 

## 📸 스크린샷

<!-- 스크린샷을 첨부해주세요. -->
<img width="380" alt="Screen Shot 2022-06-01 at 13 46 20" src="https://user-images.githubusercontent.com/30427711/171329932-f35848f9-ab44-4223-a962-91b563c1dbff.png">


close #27 
