### PR TITLE
feat: ChoiceButton 구현

### DIFF
--- a/src/components/base/Button/Button.tsx
+++ b/src/components/base/Button/Button.tsx
@@ -1,25 +1,7 @@
-import React, { ButtonHTMLAttributes } from 'react';
+import React from 'react';
 import styled, { css } from 'styled-components';
 import { palette } from '@/lib/styles/palette';
-
-export type ButtonSizes = 'small' | 'medium';
-export type ButtonVariants = 'default' | 'gray' | 'grayBlack' | 'kakao';
-export type ButtonColors = 'white' | 'gray' | 'black';
-
-export interface ButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'size' | 'color'> {
-  children: React.ReactNode;
-  size?: ButtonSizes;
-  variant?: ButtonVariants;
-  boxShadow?: boolean;
-  disabled?: boolean;
-  color?: ButtonColors;
-  fontSize?: number;
-  fontWeight?: 300 | 400 | 600 | 700;
-  fullWidth?: boolean;
-  width?: number;
-  height?: 38 | 48 | 70 | 100;
-  active?: boolean;
-}
+import { ButtonProps, sizes, getVariant } from '@/utils/buttons';
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (
@@ -97,6 +79,7 @@ const ButtonBlock = styled.button<ButtonBlockProps>`
   ${(props) =>
     props.active &&
     css`
+      font-weight: 700;
       background-color: ${palette.primary};
       color: ${palette.white};
     `}
@@ -110,86 +93,10 @@ const ButtonBlock = styled.button<ButtonBlockProps>`
   ${(props) =>
     props.disabled &&
     css`
-      font-weight: 300;
       background-color: ${palette.grayLight};
       color: rgba(0, 0, 0, 0.6);
       cursor: not-allowed;
     `}
-`;
-
-type ButtonSizeBuilder = Pick<ButtonBlockProps, 'height' | 'fontSize' | 'fontWeight'>;
-
-const buttonSizeBuilder = ({ height, fontSize, fontWeight }: ButtonSizeBuilder) => css`
-  height: ${height}px;
-  font-size: ${fontSize}px;
-  font-weight: ${fontWeight};
-`;
-
-const sizes = ({ fontSize, fontWeight, height }: Pick<ButtonProps, 'fontWeight' | 'fontSize' | 'height'>) => ({
-  small: buttonSizeBuilder({
-    height: height ?? 38,
-    fontSize: fontSize ?? 12,
-    fontWeight: fontWeight ?? 600,
-  }),
-  medium: buttonSizeBuilder({
-    height: height ?? 48,
-    fontSize: fontSize ?? 14,
-    fontWeight: fontWeight ?? 700,
-  }),
-});
-
-const getVariant = (variant: ButtonVariants, isDisabled: boolean) => css`
-  border: none;
-
-  ${variant === 'default' &&
-  css`
-    background-color: ${palette.primary};
-    color: ${palette.white};
-    font-weight: 600;
-
-    &:hover {
-      background-color: ${palette.gray};
-    }
-    ${isDisabled &&
-    css`
-      font-weight: 300;
-      background-color: ${palette.grayLight};
-      color: rgba(0, 0, 0, 0.6);
-      cursor: not-allowed;
-    `}
-  `}
-
-  ${variant === 'gray' &&
-  css`
-    background-color: ${palette.grayLight};
-    color: rgba(0, 0, 0, 0.6);
-    font-weight: 300;
-  `}
-
-${variant === 'grayBlack' &&
-  css`
-    background-color: ${palette.grayLight};
-    color: ${palette.black};
-    font-weight: 400;
-  `}
-
-
-  &:focus {
-    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
-  }
-  ${variant === 'kakao' &&
-  css`
-    background-color: ${palette.kakao};
-    color: ${palette.black};
-    font-weight: 700;
-
-    &:hover {
-    }
-  `}
-
-  &:focus {
-    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
-  }
 `;
 
 Button.displayName = 'Button';

--- a/src/components/base/ChoiceButton.tsx
+++ b/src/components/base/ChoiceButton.tsx
@@ -1,4 +1,4 @@
-import React, { LabelHTMLAttributes } from 'react';
+import React, { InputHTMLAttributes, LabelHTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
 import { palette } from '@/lib/styles/palette';
 
@@ -6,10 +6,25 @@ export type ButtonSizes = 'small' | 'medium';
 export type ButtonVariants = 'default' | 'gray' | 'grayBlack';
 export type ButtonColors = 'white' | 'gray' | 'black';
 
-export interface LabelProps extends Omit<LabelHTMLAttributes<HTMLLabelElement>, 'size' | 'color' | 'for'> {
+export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'color'> {
   isMultiple?: boolean;
-  name?: string;
+  name: string;
+  id: string;
+  checked?: boolean;
+  children: React.ReactNode;
+  size?: ButtonSizes;
+  variant?: ButtonVariants;
+  boxShadow?: boolean;
+  color?: ButtonColors;
+  fontSize?: number;
+  fontWeight?: 300 | 400 | 600 | 700;
+  fullWidth?: boolean;
+  width?: number;
+  height?: 38 | 48 | 70 | 100;
+}
+export interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
   id?: string;
+  checked?: boolean;
   children: React.ReactNode;
   size?: ButtonSizes;
   variant?: ButtonVariants;
@@ -24,8 +39,9 @@ export interface LabelProps extends Omit<LabelHTMLAttributes<HTMLLabelElement>, 
 
 const ChoiceButton = ({
   isMultiple = false,
-  name,
   id,
+  name,
+  checked,
   children,
   size = 'small',
   fontSize,
@@ -37,10 +53,14 @@ const ChoiceButton = ({
   height,
   fontWeight,
   ...others
-}: LabelProps) => {
+}: InputProps) => {
   return (
     <>
-      {isMultiple ? <InputBlock type="checkbox" id={id} name={name} /> : <InputBlock type="radio" id={id} name={name} />}
+      {isMultiple ? (
+        <InputBlock type="checkbox" id={id} name={name} checked={checked} {...others} />
+      ) : (
+        <InputBlock type="radio" id={id} name={name} {...others} />
+      )}
       <Label
         htmlFor={id}
         size={size}
@@ -52,7 +72,6 @@ const ChoiceButton = ({
         fullWidth={fullWidth}
         width={width}
         height={height}
-        {...others}
       >
         {children}
       </Label>

--- a/src/components/base/ChoiceButton.tsx
+++ b/src/components/base/ChoiceButton.tsx
@@ -1,40 +1,29 @@
 import React, { InputHTMLAttributes, LabelHTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
 import { palette } from '@/lib/styles/palette';
+import { ButtonSizes, ButtonVariants, ButtonColors, sizes, getVariant } from '@/utils/buttons';
 
-export type ButtonSizes = 'small' | 'medium';
-export type ButtonVariants = 'default' | 'gray' | 'grayBlack';
-export type ButtonColors = 'white' | 'gray' | 'black';
-
-export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'color'> {
+type ChoiceButtonVariants = Exclude<ButtonVariants, 'kakao'>;
+interface CommonProps {
+  checked?: boolean;
+  children: React.ReactNode;
+  boxShadow?: boolean;
+  color?: ButtonColors;
+  fontSize?: number;
+  fontWeight?: 300 | 400 | 600 | 700;
+  fullWidth?: boolean;
+  width?: number;
+  height?: 38 | 48 | 70 | 100;
+  variant?: ChoiceButtonVariants;
+  size?: ButtonSizes;
+}
+interface InputBaseProps extends CommonProps, Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'color' | 'children' | 'height' | 'width'> {
   isMultiple?: boolean;
   name: string;
   id: string;
-  checked?: boolean;
-  children: React.ReactNode;
-  size?: ButtonSizes;
-  variant?: ButtonVariants;
-  boxShadow?: boolean;
-  color?: ButtonColors;
-  fontSize?: number;
-  fontWeight?: 300 | 400 | 600 | 700;
-  fullWidth?: boolean;
-  width?: number;
-  height?: 38 | 48 | 70 | 100;
 }
-export interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
+interface LabelProps extends CommonProps, Omit<LabelHTMLAttributes<HTMLLabelElement>, 'children' | 'color'> {
   id?: string;
-  checked?: boolean;
-  children: React.ReactNode;
-  size?: ButtonSizes;
-  variant?: ButtonVariants;
-  boxShadow?: boolean;
-  color?: ButtonColors;
-  fontSize?: number;
-  fontWeight?: 300 | 400 | 600 | 700;
-  fullWidth?: boolean;
-  width?: number;
-  height?: 38 | 48 | 70 | 100;
 }
 
 const ChoiceButton = ({
@@ -53,7 +42,7 @@ const ChoiceButton = ({
   height,
   fontWeight,
   ...others
-}: InputProps) => {
+}: InputBaseProps) => {
   return (
     <>
       {isMultiple ? (
@@ -135,61 +124,6 @@ const Label = styled.label<ChoiceButtonBlockProps>`
     css`
       box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
     `};
-`;
-
-type ButtonSizeBuilder = Pick<ChoiceButtonBlockProps, 'height' | 'fontSize' | 'fontWeight'>;
-
-const buttonSizeBuilder = ({ height, fontSize, fontWeight }: ButtonSizeBuilder) => css`
-  height: ${height}px;
-  font-size: ${fontSize}px;
-  font-weight: ${fontWeight};
-`;
-
-const sizes = ({ fontSize, fontWeight, height }: Pick<ChoiceButtonBlockProps, 'fontWeight' | 'fontSize' | 'height'>) => ({
-  small: buttonSizeBuilder({
-    height: height ?? 38,
-    fontSize: fontSize ?? 12,
-    fontWeight: fontWeight ?? 600,
-  }),
-  medium: buttonSizeBuilder({
-    height: height ?? 48,
-    fontSize: fontSize ?? 14,
-    fontWeight: fontWeight ?? 700,
-  }),
-});
-
-const getVariant = (variant: ButtonVariants) => css`
-  border: none;
-
-  ${variant === 'default' &&
-  css`
-    background-color: ${palette.primary};
-    color: ${palette.white};
-    font-weight: 600;
-
-    &:hover {
-      background-color: ${palette.gray};
-    }
-  `}
-
-  ${variant === 'gray' &&
-  css`
-    background-color: ${palette.grayLight};
-    color: rgba(0, 0, 0, 0.6);
-    font-weight: 400;
-  `}
-
-${variant === 'grayBlack' &&
-  css`
-    background-color: ${palette.grayLight};
-    color: ${palette.black};
-    font-weight: 400;
-  `}
-
-
-  &:focus {
-    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
-  }
 `;
 
 export default ChoiceButton;

--- a/src/components/base/ChoiceButton.tsx
+++ b/src/components/base/ChoiceButton.tsx
@@ -1,0 +1,176 @@
+import React, { LabelHTMLAttributes } from 'react';
+import styled, { css } from 'styled-components';
+import { palette } from '@/lib/styles/palette';
+
+export type ButtonSizes = 'small' | 'medium';
+export type ButtonVariants = 'default' | 'gray' | 'grayBlack';
+export type ButtonColors = 'white' | 'gray' | 'black';
+
+export interface LabelProps extends Omit<LabelHTMLAttributes<HTMLLabelElement>, 'size' | 'color' | 'for'> {
+  isMultiple?: boolean;
+  name?: string;
+  id?: string;
+  children: React.ReactNode;
+  size?: ButtonSizes;
+  variant?: ButtonVariants;
+  boxShadow?: boolean;
+  color?: ButtonColors;
+  fontSize?: number;
+  fontWeight?: 300 | 400 | 600 | 700;
+  fullWidth?: boolean;
+  width?: number;
+  height?: 38 | 48 | 70 | 100;
+}
+
+const ChoiceButton = ({
+  isMultiple = false,
+  name,
+  id,
+  children,
+  size = 'small',
+  fontSize,
+  variant = 'default',
+  boxShadow = false,
+  color = 'white',
+  fullWidth = true,
+  width,
+  height,
+  fontWeight,
+  ...others
+}: LabelProps) => {
+  return (
+    <>
+      {isMultiple ? <InputBlock type="checkbox" id={id} name={name} /> : <InputBlock type="radio" id={id} name={name} />}
+      <Label
+        htmlFor={id}
+        size={size}
+        variant={variant}
+        boxShadow={boxShadow}
+        color={color}
+        fontSize={fontSize}
+        fontWeight={fontWeight}
+        fullWidth={fullWidth}
+        width={width}
+        height={height}
+        {...others}
+      >
+        {children}
+      </Label>
+    </>
+  );
+};
+
+type ChoiceButtonBlockProps = Omit<LabelProps, 'children'>;
+
+const InputBlock = styled.input`
+  width: 0;
+  height: 0;
+  position: absolute;
+  left: -9999px;
+
+  &[type='radio']:checked + label {
+    font-weight: 700;
+    background-color: ${palette.primary};
+    color: ${palette.white};
+  }
+
+  &[type='checkbox']:checked + label {
+    font-weight: 700;
+    background-color: ${palette.primary};
+    color: ${palette.white};
+  }
+`;
+
+const Label = styled.label<ChoiceButtonBlockProps>`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  user-select: none;
+  white-space: nowrap;
+  max-width: 100%;
+  outline: none;
+  border-radius: 4px;
+  transition: background-color 300ms, box-shadow 300ms;
+  cursor: pointer;
+  z-index: 1;
+
+  ${({ size, fontWeight, fontSize, height }) => sizes({ fontSize, fontWeight, height })[size ?? 'small']};
+  ${(props) => getVariant(props.variant ?? 'default')};
+
+  ${(props) =>
+    props.fullWidth &&
+    css`
+      width: 100%;
+      max-width: 100%;
+    `}
+
+  ${(props) =>
+    props.width &&
+    css`
+      width: ${props.width}px;
+    `}
+
+  ${(props) =>
+    props.boxShadow &&
+    css`
+      box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+    `};
+`;
+
+type ButtonSizeBuilder = Pick<ChoiceButtonBlockProps, 'height' | 'fontSize' | 'fontWeight'>;
+
+const buttonSizeBuilder = ({ height, fontSize, fontWeight }: ButtonSizeBuilder) => css`
+  height: ${height}px;
+  font-size: ${fontSize}px;
+  font-weight: ${fontWeight};
+`;
+
+const sizes = ({ fontSize, fontWeight, height }: Pick<ChoiceButtonBlockProps, 'fontWeight' | 'fontSize' | 'height'>) => ({
+  small: buttonSizeBuilder({
+    height: height ?? 38,
+    fontSize: fontSize ?? 12,
+    fontWeight: fontWeight ?? 600,
+  }),
+  medium: buttonSizeBuilder({
+    height: height ?? 48,
+    fontSize: fontSize ?? 14,
+    fontWeight: fontWeight ?? 700,
+  }),
+});
+
+const getVariant = (variant: ButtonVariants) => css`
+  border: none;
+
+  ${variant === 'default' &&
+  css`
+    background-color: ${palette.primary};
+    color: ${palette.white};
+    font-weight: 600;
+
+    &:hover {
+      background-color: ${palette.gray};
+    }
+  `}
+
+  ${variant === 'gray' &&
+  css`
+    background-color: ${palette.grayLight};
+    color: rgba(0, 0, 0, 0.6);
+    font-weight: 400;
+  `}
+
+${variant === 'grayBlack' &&
+  css`
+    background-color: ${palette.grayLight};
+    color: ${palette.black};
+    font-weight: 400;
+  `}
+
+
+  &:focus {
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+  }
+`;
+
+export default ChoiceButton;

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -1,3 +1,4 @@
 export { default as Button } from './Button/Button';
+export { default as ChoiceButton } from './ChoiceButton';
 export { default as Input } from './Input';
 export { default as Modal } from './Modal';

--- a/src/utils/buttons.ts
+++ b/src/utils/buttons.ts
@@ -1,0 +1,97 @@
+import React, { ButtonHTMLAttributes } from 'react';
+import { css } from 'styled-components';
+import { palette } from '@/lib/styles/palette';
+
+export type ButtonSizes = 'small' | 'medium';
+export type ButtonVariants = 'default' | 'gray' | 'grayBlack' | 'kakao';
+export type ButtonColors = 'white' | 'gray' | 'black';
+
+export interface ButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'size' | 'color'> {
+  children: React.ReactNode;
+  size?: ButtonSizes;
+  variant?: ButtonVariants;
+  boxShadow?: boolean;
+  disabled?: boolean;
+  color?: ButtonColors;
+  fontSize?: number;
+  fontWeight?: 300 | 400 | 600 | 700;
+  fullWidth?: boolean;
+  width?: number;
+  height?: 38 | 48 | 70 | 100;
+  active?: boolean;
+}
+
+type ButtonSizeBuilder = Pick<ButtonProps, 'height' | 'fontSize' | 'fontWeight'>;
+
+export const buttonSizeBuilder = ({ height, fontSize, fontWeight }: ButtonSizeBuilder) => css`
+  height: ${height}px;
+  font-size: ${fontSize}px;
+  font-weight: ${fontWeight};
+`;
+
+export const sizes = ({ fontSize, fontWeight, height }: Pick<ButtonProps, 'fontWeight' | 'fontSize' | 'height'>) => ({
+  small: buttonSizeBuilder({
+    height: height ?? 38,
+    fontSize: fontSize ?? 12,
+    fontWeight: fontWeight ?? 600,
+  }),
+  medium: buttonSizeBuilder({
+    height: height ?? 48,
+    fontSize: fontSize ?? 14,
+    fontWeight: fontWeight ?? 700,
+  }),
+});
+
+export const getVariant = (variant: ButtonVariants, isDisabled?: boolean) => css`
+  border: none;
+
+  ${variant === 'default' &&
+  css`
+    background-color: ${palette.primary};
+    color: ${palette.white};
+    font-weight: 600;
+
+    &:hover {
+      background-color: ${palette.gray};
+    }
+    ${isDisabled &&
+    css`
+      font-weight: 300;
+      background-color: ${palette.grayLight};
+      color: rgba(0, 0, 0, 0.6);
+      cursor: not-allowed;
+    `}
+  `}
+
+  ${variant === 'gray' &&
+  css`
+    background-color: ${palette.grayLight};
+    color: rgba(0, 0, 0, 0.6);
+    font-weight: 400;
+  `}
+
+${variant === 'grayBlack' &&
+  css`
+    background-color: ${palette.grayLight};
+    color: ${palette.black};
+    font-weight: 400;
+  `}
+
+
+  &:focus {
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+  }
+  ${variant === 'kakao' &&
+  css`
+    background-color: ${palette.kakao};
+    color: ${palette.black};
+    font-weight: 700;
+
+    &:hover {
+    }
+  `}
+
+  &:focus {
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+  }
+`;


### PR DESCRIPTION
## 🧑‍💻 PR 내용

- Closes #36 

- 일반 버튼이 아닌 input 태그의 radio와 checkbox로 단일 /  멀티 버튼 선택 구현하였습니다.
- `isMultiple` prop을 추가할 경우 checkbox로 다중 선택이 가능하며, 아닐 경우는 radio 타입이 됩니다.
- `name` 으로 한 집합이 되며, id를 필수로 넣어주어야 컴포넌트 내부의 input과 label이 통일됩니다.
- checked 값을 얻고 싶을 땐 `onChange` 를 사용합니다.

```tsx
<ChoiceButton name="typeOfmeeting" size="medium" variant="grayBlack" id="blindDate" onChange={onChange}>
  1:1 소개팅
</ChoiceButton>
<ChoiceButton name="typeOfmeeting" size="medium" variant="grayBlack" id="twoByTwoMeeting" onChange={onChange}>
   2:2 미팅
</ChoiceButton>

<ChoiceButton isMultiple name="class" size="medium" variant="grayBlack" id="moon" onChange={onChange}>
  문과
</ChoiceButton>
<ChoiceButton isMultiple name="class" size="medium" variant="grayBlack" id="eee" onChange={onChange}>
   이과
</ChoiceButton>
```
<!-- 수정/추가한 내용을 적어주세요. -->

## 📸 스크린샷

<img width="372" alt="image" src="https://user-images.githubusercontent.com/68528752/171423510-ce4f5ee0-b16d-4984-9661-8e624d4fca5a.png">

<!-- 스크린샷을 첨부해주세요. -->

