### PR TITLE
Feat: 미팅 설문 상태 recoil & sessionStorage로 변경

### DIFF
--- a/src/atoms/meetingState.ts
+++ b/src/atoms/meetingState.ts
@@ -30,7 +30,7 @@ const INITIAL_MEETING_STATE: Meeting = {
 };
 
 const meetingState = atom<Meeting>({
-  key: 'meeting/meetingState',
+  key: 'meetingState',
   default: INITIAL_MEETING_STATE,
   effects_UNSTABLE: [persistAtom],
 });

--- a/src/atoms/meetingState.ts
+++ b/src/atoms/meetingState.ts
@@ -13,7 +13,7 @@ const INITIAL_MEETING_STATE: Meeting = {
   averageAge: 28,
   ourUniversities: [],
   ourDepartments: ['LIBERAL', 'SCIENCE'],
-  averageHeight: [140, 180],
+  averageHeight: 170,
   avoidUniversities: [],
   preferUniversities: [],
   preferAge: [20, 25],

--- a/src/components/base/MultiRangeSlider.tsx
+++ b/src/components/base/MultiRangeSlider.tsx
@@ -1,18 +1,18 @@
 import styled from 'styled-components';
 import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
 
-export interface Ranges {
+export interface MultiRangeSliderProps {
+  initValue: number[];
   min: number;
   max: number;
+  onChange?: (rangeValues: OnChangeProps) => void;
 }
 
-interface MultiRangeSliderProps extends Ranges {
-  onChange?: (rangeValues: Ranges) => void;
-}
+export type OnChangeProps = Omit<MultiRangeSliderProps, 'initValue' | 'onChange'>;
 
-const MultiRangeSlider = ({ min, max, onChange }: MultiRangeSliderProps) => {
-  const [minVal, setMinVal] = useState(min);
-  const [maxVal, setMaxVal] = useState(max);
+const MultiRangeSlider = ({ initValue, min, max, onChange }: MultiRangeSliderProps) => {
+  const [minVal, setMinVal] = useState(initValue[0]);
+  const [maxVal, setMaxVal] = useState(initValue[1]);
   const minValRef = useRef<HTMLInputElement>(null);
   const maxValRef = useRef<HTMLInputElement>(null);
   const range = useRef<HTMLDivElement>(null);

--- a/src/components/base/SimpleRangeSlider.tsx
+++ b/src/components/base/SimpleRangeSlider.tsx
@@ -4,15 +4,15 @@ import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
 interface SimpleRangeSliderProps {
   min: number;
   max: number;
-  ageOption: number;
+  initValue: number;
   isStep5?: boolean;
   onChange?: (rangeValues: OnChangeProps) => void;
 }
 
-export type OnChangeProps = Omit<SimpleRangeSliderProps, 'ageOption' | 'onChange'>;
+export type OnChangeProps = Omit<SimpleRangeSliderProps, 'initValue' | 'onChange'>;
 
-const SimpleRangeSlider = ({ min, max, ageOption, isStep5 = false, onChange }: SimpleRangeSliderProps) => {
-  const [maxVal, setMaxVal] = useState(ageOption);
+const SimpleRangeSlider = ({ min, max, initValue, isStep5 = false, onChange }: SimpleRangeSliderProps) => {
+  const [maxVal, setMaxVal] = useState(initValue);
   const maxValRef = useRef<HTMLInputElement>(null);
   const range = useRef<HTMLDivElement>(null);
   const sign = useRef<HTMLSpanElement>(null);

--- a/src/components/base/SimpleRangeSlider.tsx
+++ b/src/components/base/SimpleRangeSlider.tsx
@@ -1,30 +1,24 @@
 import styled from 'styled-components';
 import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
 
-export interface Ranges {
+interface SimpleRangeSliderProps {
   min: number;
   max: number;
+  ageOption: number;
   isStep5?: boolean;
+  onChange?: (rangeValues: OnChangeProps) => void;
 }
 
-interface SimpleRangeSliderProps extends Ranges {
-  onChange?: (rangeValues: Ranges) => void;
-}
+export type OnChangeProps = Omit<SimpleRangeSliderProps, 'ageOption' | 'onChange'>;
 
-const SimpleRangeSlider = ({ min, max, isStep5 = false, onChange }: SimpleRangeSliderProps) => {
-  const [maxVal, setMaxVal] = useState(Math.ceil((min + max) / 2));
+const SimpleRangeSlider = ({ min, max, ageOption, isStep5 = false, onChange }: SimpleRangeSliderProps) => {
+  const [maxVal, setMaxVal] = useState(ageOption);
   const maxValRef = useRef<HTMLInputElement>(null);
   const range = useRef<HTMLDivElement>(null);
   const sign = useRef<HTMLSpanElement>(null);
 
   const getPercent = useCallback((value: number) => Math.round(((value - min) / (max - min)) * 100), [min, max]);
   const getMidValue = useCallback(
-    (midLevel: 1 | 2) => {
-      return min + Math.floor((max - min) / 3) * midLevel;
-    },
-    [min, max],
-  );
-  const getMidValueWith5Steps = useCallback(
     (midLevel: 1 | 2) => {
       return min + Math.floor((max - min) / 3) * midLevel;
     },

--- a/src/components/domain/survey/AgeBox.tsx
+++ b/src/components/domain/survey/AgeBox.tsx
@@ -5,8 +5,9 @@ import { SimpleRangeSlider, MultiRangeSlider } from '@/components/base';
 import { OnChangeProps } from '@/components/base/SimpleRangeSlider';
 
 interface AgeBoxProps {
-  ageOption: number;
+  ageOption?: number;
   setAgeOption?: React.Dispatch<React.SetStateAction<number>>;
+  multiAgeOption: number[];
   setMultiAgeOption?: React.Dispatch<React.SetStateAction<number[]>>;
   children: React.ReactNode;
   isMulti?: boolean;
@@ -15,7 +16,7 @@ interface AgeBoxProps {
 export const MIN_AGE = 20;
 export const MAX_AGE = 35;
 
-const AgeBox = ({ ageOption, setAgeOption, setMultiAgeOption, children, isMulti = false }: AgeBoxProps) => {
+const AgeBox = ({ ageOption, setAgeOption, multiAgeOption, setMultiAgeOption, children, isMulti = false }: AgeBoxProps) => {
   const handleSimpleChange = useCallback(
     ({ max }: OnChangeProps) => {
       if (!isMulti && setAgeOption) {
@@ -39,9 +40,9 @@ const AgeBox = ({ ageOption, setAgeOption, setMultiAgeOption, children, isMulti 
       <SubTitle>{children}</SubTitle>
       <RangeWrapper>
         {isMulti ? (
-          <MultiRangeSlider min={MIN_AGE} max={MAX_AGE} onChange={handleMultiChange} />
+          <MultiRangeSlider min={MIN_AGE} max={MAX_AGE} initValue={multiAgeOption ?? [MIN_AGE, MAX_AGE]} onChange={handleMultiChange} />
         ) : (
-          <SimpleRangeSlider min={MIN_AGE} max={MAX_AGE} initValue={ageOption} onChange={handleSimpleChange} />
+          <SimpleRangeSlider min={MIN_AGE} max={MAX_AGE} initValue={ageOption ?? MAX_AGE} onChange={handleSimpleChange} />
         )}
       </RangeWrapper>
     </Container>

--- a/src/components/domain/survey/AgeBox.tsx
+++ b/src/components/domain/survey/AgeBox.tsx
@@ -41,7 +41,7 @@ const AgeBox = ({ ageOption, setAgeOption, setMultiAgeOption, children, isMulti 
         {isMulti ? (
           <MultiRangeSlider min={MIN_AGE} max={MAX_AGE} onChange={handleMultiChange} />
         ) : (
-          <SimpleRangeSlider min={MIN_AGE} max={MAX_AGE} ageOption={ageOption} onChange={handleSimpleChange} />
+          <SimpleRangeSlider min={MIN_AGE} max={MAX_AGE} initValue={ageOption} onChange={handleSimpleChange} />
         )}
       </RangeWrapper>
     </Container>

--- a/src/components/domain/survey/AgeBox.tsx
+++ b/src/components/domain/survey/AgeBox.tsx
@@ -2,9 +2,10 @@ import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import { SubTitle } from '@/lib/styles/styledComponents';
 import { SimpleRangeSlider, MultiRangeSlider } from '@/components/base';
-import { Ranges } from '@/components/base/SimpleRangeSlider';
+import { OnChangeProps } from '@/components/base/SimpleRangeSlider';
 
 interface AgeBoxProps {
+  ageOption: number;
   setAgeOption?: React.Dispatch<React.SetStateAction<number>>;
   setMultiAgeOption?: React.Dispatch<React.SetStateAction<number[]>>;
   children: React.ReactNode;
@@ -14,9 +15,9 @@ interface AgeBoxProps {
 export const MIN_AGE = 20;
 export const MAX_AGE = 35;
 
-const AgeBox = ({ setAgeOption, setMultiAgeOption, children, isMulti = false }: AgeBoxProps) => {
+const AgeBox = ({ ageOption, setAgeOption, setMultiAgeOption, children, isMulti = false }: AgeBoxProps) => {
   const handleSimpleChange = useCallback(
-    ({ max }: Ranges) => {
+    ({ max }: OnChangeProps) => {
       if (!isMulti && setAgeOption) {
         setAgeOption(max);
       }
@@ -25,7 +26,7 @@ const AgeBox = ({ setAgeOption, setMultiAgeOption, children, isMulti = false }: 
   );
 
   const handleMultiChange = useCallback(
-    ({ min, max }: Ranges) => {
+    ({ min, max }: OnChangeProps) => {
       if (isMulti && setMultiAgeOption) {
         setMultiAgeOption([min, max]);
       }
@@ -40,7 +41,7 @@ const AgeBox = ({ setAgeOption, setMultiAgeOption, children, isMulti = false }: 
         {isMulti ? (
           <MultiRangeSlider min={MIN_AGE} max={MAX_AGE} onChange={handleMultiChange} />
         ) : (
-          <SimpleRangeSlider min={MIN_AGE} max={MAX_AGE} onChange={handleSimpleChange} />
+          <SimpleRangeSlider min={MIN_AGE} max={MAX_AGE} ageOption={ageOption} onChange={handleSimpleChange} />
         )}
       </RangeWrapper>
     </Container>

--- a/src/components/domain/survey/HeightBox.tsx
+++ b/src/components/domain/survey/HeightBox.tsx
@@ -2,9 +2,10 @@ import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import { SubTitle } from '@/lib/styles/styledComponents';
 import { MultiRangeSlider, SimpleRangeSlider } from '@/components/base';
-import { Ranges } from '@/components/base/SimpleRangeSlider';
+import { OnChangeProps } from '@/components/base/SimpleRangeSlider';
 
 interface HeightBoxProps {
+  heightOption: number;
   setHeightOption?: React.Dispatch<React.SetStateAction<number>>;
   setMultiHeightOption?: React.Dispatch<React.SetStateAction<number[]>>;
   children: React.ReactNode;
@@ -14,7 +15,7 @@ interface HeightBoxProps {
 export const MIN_HEIGHT = 120;
 export const MAX_HEIGHT = 220;
 
-const HeightBox = ({ setHeightOption, setMultiHeightOption, children, isMulti = false }: HeightBoxProps) => {
+const HeightBox = ({ heightOption, setHeightOption, setMultiHeightOption, children, isMulti = false }: HeightBoxProps) => {
   if (isMulti && !setMultiHeightOption) {
     throw new Error('setMultiHeightOption is required when isMulti is true');
   }
@@ -24,7 +25,7 @@ const HeightBox = ({ setHeightOption, setMultiHeightOption, children, isMulti = 
   }
 
   const handleSimpleChange = useCallback(
-    ({ max }: Ranges) => {
+    ({ max }: OnChangeProps) => {
       if (!isMulti && setHeightOption) {
         setHeightOption(max);
       }
@@ -33,7 +34,7 @@ const HeightBox = ({ setHeightOption, setMultiHeightOption, children, isMulti = 
   );
 
   const handleMultiChange = useCallback(
-    ({ min, max }: Ranges) => {
+    ({ min, max }: OnChangeProps) => {
       if (isMulti && setMultiHeightOption) {
         setMultiHeightOption([min, max]);
       }
@@ -48,7 +49,7 @@ const HeightBox = ({ setHeightOption, setMultiHeightOption, children, isMulti = 
         {isMulti ? (
           <MultiRangeSlider min={MIN_HEIGHT} max={MAX_HEIGHT} onChange={handleMultiChange} />
         ) : (
-          <SimpleRangeSlider min={MIN_HEIGHT} max={MAX_HEIGHT} onChange={handleSimpleChange} />
+          <SimpleRangeSlider min={MIN_HEIGHT} max={MAX_HEIGHT} initValue={heightOption} onChange={handleSimpleChange} />
         )}
       </RangeWrapper>
     </Container>

--- a/src/components/domain/survey/HeightBox.tsx
+++ b/src/components/domain/survey/HeightBox.tsx
@@ -5,7 +5,8 @@ import { MultiRangeSlider, SimpleRangeSlider } from '@/components/base';
 import { OnChangeProps } from '@/components/base/SimpleRangeSlider';
 
 interface HeightBoxProps {
-  heightOption: number;
+  heightOption?: number;
+  multiHeightOption?: number[];
   setHeightOption?: React.Dispatch<React.SetStateAction<number>>;
   setMultiHeightOption?: React.Dispatch<React.SetStateAction<number[]>>;
   children: React.ReactNode;
@@ -15,7 +16,7 @@ interface HeightBoxProps {
 export const MIN_HEIGHT = 120;
 export const MAX_HEIGHT = 220;
 
-const HeightBox = ({ heightOption, setHeightOption, setMultiHeightOption, children, isMulti = false }: HeightBoxProps) => {
+const HeightBox = ({ heightOption, setHeightOption, multiHeightOption, setMultiHeightOption, children, isMulti = false }: HeightBoxProps) => {
   if (isMulti && !setMultiHeightOption) {
     throw new Error('setMultiHeightOption is required when isMulti is true');
   }
@@ -47,9 +48,14 @@ const HeightBox = ({ heightOption, setHeightOption, setMultiHeightOption, childr
       <SubTitle>{children}</SubTitle>
       <RangeWrapper>
         {isMulti ? (
-          <MultiRangeSlider min={MIN_HEIGHT} max={MAX_HEIGHT} onChange={handleMultiChange} />
+          <MultiRangeSlider
+            initValue={multiHeightOption ?? [MIN_HEIGHT, MAX_HEIGHT]}
+            min={MIN_HEIGHT}
+            max={MAX_HEIGHT}
+            onChange={handleMultiChange}
+          />
         ) : (
-          <SimpleRangeSlider min={MIN_HEIGHT} max={MAX_HEIGHT} initValue={heightOption} onChange={handleSimpleChange} />
+          <SimpleRangeSlider min={MIN_HEIGHT} max={MAX_HEIGHT} initValue={heightOption ?? MAX_HEIGHT} onChange={handleSimpleChange} />
         )}
       </RangeWrapper>
     </Container>

--- a/src/hooks/common/index.ts
+++ b/src/hooks/common/index.ts
@@ -1,3 +1,5 @@
 export { default as useForm } from './useForm';
 export { default as useCountdown } from './useCountdown';
 export { default as useToggle } from './useToggle';
+export { default as useSesstionStorage } from './useSesstionStorage';
+export { default as useMeetingSessionState } from './useMeetingSessionState';

--- a/src/hooks/common/useMeetingSessionState.ts
+++ b/src/hooks/common/useMeetingSessionState.ts
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+import { useMeetingState } from '@/atoms/meetingState';
+import { type Meeting } from '@/types/meeting';
+import { useSesstionStorage } from './';
+
+function useMeetingSessionState() {
+  const { meetingData: meetingAtomData, setMeetingData } = useMeetingState();
+  const [initMeetingState, setInitState] = useState<Meeting>(meetingAtomData);
+  const { getValueFromSessionStorage } = useSesstionStorage();
+
+  useEffect(() => {
+    const sessionData = getValueFromSessionStorage('meeting');
+    if (sessionData) {
+      const { meetingState } = JSON.parse(sessionData);
+      setInitState(meetingState);
+      return;
+    }
+    setInitState(meetingAtomData);
+  }, [meetingAtomData]);
+
+  return { initMeetingState, setMeetingData };
+}
+
+export default useMeetingSessionState;

--- a/src/hooks/common/useSesstionStorage.ts
+++ b/src/hooks/common/useSesstionStorage.ts
@@ -1,0 +1,16 @@
+function useSesstionStorage() {
+  function getValueFromSessionStorage(key: string) {
+    return sessionStorage.getItem(key);
+  }
+
+  function setValueToSessionStorage(key: string, value: any) {
+    return sessionStorage.setItem(key, value);
+  }
+
+  return {
+    getValueFromSessionStorage,
+    setValueToSessionStorage,
+  };
+}
+
+export default useSesstionStorage;

--- a/src/pages/GenderAverageAgeSurvey.tsx
+++ b/src/pages/GenderAverageAgeSurvey.tsx
@@ -2,31 +2,39 @@ import React, { useState } from 'react';
 import { SurveyTemplate, AgeBox } from '@/components/domain/survey';
 import { Title } from '@/lib/styles/styledComponents';
 import styled from 'styled-components';
-import { MIN_AGE, MAX_AGE } from '@/components/domain/survey/AgeBox';
 import ChooseTwoBox from '@/components/domain/survey/ChooseTwoBox';
 import { useMeetingNavigate } from '@/hooks/common/useMeetingNavigate';
 import Path from '@/router/Path';
 import { useNavigate } from 'react-router-dom';
 import { GENDER_ITEMS } from '@/types/constants/constant';
-
-export type GenderOptions = 'FEMAIL' | 'MALE';
+import { useMeetingSessionState } from '@/hooks/common';
+import { type Gender } from '@/types/meeting';
 
 const GenderAverageAgeSurvey = () => {
   const navigate = useNavigate();
   const meetingNavigate = useMeetingNavigate();
-  const [genderOption, setGenderOption] = useState<GenderOptions>('FEMAIL');
-  const [ageOption, setAgeOption] = useState(Math.floor((MIN_AGE + MAX_AGE) / 2));
+  const { initMeetingState, setMeetingData } = useMeetingSessionState();
+  const [genderOption, setGenderOption] = useState(initMeetingState.gender);
+  const [ageOption, setAgeOption] = useState(initMeetingState.averageAge);
   const onChangeOption = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { id } = e.target;
-    setGenderOption(id as GenderOptions);
+    setGenderOption(id as Gender);
   };
+  const handleNextClick = () => {
+    if (initMeetingState) {
+      setMeetingData({ ...initMeetingState, gender: genderOption, averageAge: ageOption });
+    }
+
+    meetingNavigate(Path.OurUniversitiesSurvey);
+  };
+
   return (
     <SurveyTemplate
-      disableNext={!ageOption && !genderOption}
+      disableNext={!ageOption || !genderOption}
       currStep={2}
       totalStep={14}
       handlePrevClick={() => navigate(Path.TypeOfMeetingSurvey)}
-      handleNextClick={() => meetingNavigate(Path.OurUniversitiesSurvey)}
+      handleNextClick={handleNextClick}
     >
       <StyledTitle>
         <strong>2:2 미팅</strong>을 선택하셨어요.
@@ -38,7 +46,9 @@ const GenderAverageAgeSurvey = () => {
       <ChooseTwoBox items={GENDER_ITEMS} selectedOption={genderOption} onChangeOption={onChangeOption}>
         성별을 선택해주세요.
       </ChooseTwoBox>
-      <AgeBox setAgeOption={setAgeOption}>참여자의 평균 나이를 알려주세요.</AgeBox>
+      <AgeBox setAgeOption={setAgeOption} ageOption={ageOption}>
+        참여자의 평균 나이를 알려주세요.
+      </AgeBox>
     </SurveyTemplate>
   );
 };

--- a/src/pages/IsAbroadSurvey.tsx
+++ b/src/pages/IsAbroadSurvey.tsx
@@ -6,16 +6,28 @@ import styled from 'styled-components';
 import { FormWrapper } from './AuthMail';
 import { useMeetingNavigate } from '@/hooks/common/useMeetingNavigate';
 import Path from '@/router/Path';
-import { Abroad } from '@/types/enums';
 import { COUNTRY_ITEMS } from '@/types/constants/area';
+import { useMeetingSessionState } from '@/hooks/common';
+import { type Location } from '@/types/meeting';
 
 const IsAbroadSurvey = () => {
   const meetingNavigate = useMeetingNavigate();
-  const [isAbroad, setIsAbroad] = useState<Abroad>(Abroad.domestic);
+  const { initMeetingState, setMeetingData } = useMeetingSessionState();
+  const [isAbroad, setIsAbroad] = useState<Location>(initMeetingState.isAbroad ? 'ABROAD' : 'DOMESTIC');
+
   const onChangeOption = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { id } = e.target;
-    setIsAbroad(id as Abroad);
+    setIsAbroad(id as Location);
   };
+
+  const handleNextClick = () => {
+    if (initMeetingState) {
+      setMeetingData({ ...initMeetingState, isAbroad: isAbroad === 'ABROAD' ? true : false });
+    }
+
+    meetingNavigate(isAbroad === 'ABROAD' ? Path.AbroadAreasSurvey : Path.DomesticAreasSurvey);
+  };
+
   return (
     <SurveyTemplate
       disableNext={false}
@@ -23,7 +35,7 @@ const IsAbroadSurvey = () => {
       currStep={11}
       totalStep={14}
       handlePrevClick={() => meetingNavigate(Path.PlaySurvey)}
-      handleNextClick={() => meetingNavigate(isAbroad === Abroad.abroad ? Path.AbroadAreasSurvey : Path.DomesticAreasSurvey)}
+      handleNextClick={handleNextClick}
     >
       <Title>
         지금 한국이신가요? <br />

--- a/src/pages/MindsetSurvey.tsx
+++ b/src/pages/MindsetSurvey.tsx
@@ -6,16 +6,25 @@ import styled from 'styled-components';
 import { MINDSET_ITEMS } from '@/types/constants/constant';
 import Path from '@/router/Path';
 import { useMeetingNavigate } from '@/hooks/common/useMeetingNavigate';
-
-export type ChoiceOptions = 'ALL' | 'FRIEND' | 'LOVE';
+import { useMeetingSessionState } from '@/hooks/common';
+import { type MindSet } from '@/types/meeting';
 
 const MindsetSurvey = () => {
   const meetingNavigate = useMeetingNavigate();
-  const [checkedOption, setCheckedOption] = useState<ChoiceOptions>('ALL');
+  const { initMeetingState, setMeetingData } = useMeetingSessionState();
+  const [checkedOption, setCheckedOption] = useState<MindSet>(initMeetingState.mindset);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { id } = e.target;
-    setCheckedOption(id as ChoiceOptions);
+    setCheckedOption(id as MindSet);
+  };
+
+  const handleNextClick = () => {
+    if (initMeetingState) {
+      setMeetingData({ ...initMeetingState, mindset: checkedOption });
+    }
+
+    meetingNavigate(Path.PlaySurvey);
   };
 
   return (
@@ -24,7 +33,7 @@ const MindsetSurvey = () => {
       currStep={9}
       totalStep={14}
       handlePrevClick={() => meetingNavigate(Path.PreferAgeHeightSurvey)}
-      handleNextClick={() => meetingNavigate(Path.PlaySurvey)}
+      handleNextClick={handleNextClick}
     >
       <Title>
         <strong>미팅의 마인드셋</strong>을

--- a/src/pages/OurDepartmentsAverageHeightSurvey.tsx
+++ b/src/pages/OurDepartmentsAverageHeightSurvey.tsx
@@ -1,17 +1,42 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { SurveyTemplate } from '@/components/domain/survey';
 import { Title } from '@/lib/styles/styledComponents';
 import { ChooseFourBox, HeightBox } from '@/components/domain/survey';
 import { ChooseFourBoxItemProps } from '@/components/domain/survey/ChooseFourBox';
-import { MIN_HEIGHT, MAX_HEIGHT } from '@/components/domain/survey/HeightBox';
 import { OUR_DEPARTMENT_ITEMS } from '@/types/constants/department';
 import Path from '@/router/Path';
 import { useMeetingNavigate } from '@/hooks/common/useMeetingNavigate';
+import { useMeetingSessionState } from '@/hooks/common';
+import { type Departments } from '@/types/meeting';
+
+export interface ChooseFourDepartmentProps extends ChooseFourBoxItemProps {
+  id: Departments;
+}
 
 const OurDepartmentsAverageHeightSurvey = () => {
   const meetingNavigate = useMeetingNavigate();
-  const [checkedMultiOption, setMultiCheckedOption] = useState<ChooseFourBoxItemProps[]>(OUR_DEPARTMENT_ITEMS);
-  const [heightOption, setHeightOption] = useState(Math.floor((MIN_HEIGHT + MAX_HEIGHT) / 2));
+  const { initMeetingState, setMeetingData } = useMeetingSessionState();
+  const getInitDepartments = OUR_DEPARTMENT_ITEMS.map((item) => {
+    return { ...item, checked: initMeetingState.ourDepartments.some((initState) => initState === item.id) };
+  });
+  const initDepartments = useMemo(() => getInitDepartments, [OUR_DEPARTMENT_ITEMS, initMeetingState]);
+  const [checkedMultiOption, setMultiCheckedOption] = useState<ChooseFourBoxItemProps[]>(initDepartments);
+  const getOurDepartments = checkedMultiOption.reduce<Departments[]>((prev, cur) => {
+    if (cur.checked) {
+      prev.push(cur.id as Departments);
+    }
+    return prev;
+  }, []);
+  const ourDepartments = useMemo(() => getOurDepartments, [checkedMultiOption]);
+  const [heightOption, setHeightOption] = useState(initMeetingState.averageHeight);
+
+  const handleNextClick = () => {
+    if (initMeetingState) {
+      setMeetingData({ ...initMeetingState, ourDepartments: ourDepartments ?? [], averageHeight: heightOption });
+    }
+
+    meetingNavigate(Path.AvoidUniversitiesSurvey);
+  };
 
   return (
     <SurveyTemplate
@@ -19,7 +44,7 @@ const OurDepartmentsAverageHeightSurvey = () => {
       currStep={4}
       totalStep={14}
       handlePrevClick={() => meetingNavigate(Path.OurUniversitiesSurvey)}
-      handleNextClick={() => meetingNavigate(Path.AvoidUniversitiesSurvey)}
+      handleNextClick={handleNextClick}
     >
       <Title>
         <strong>참여자의 학과</strong>를
@@ -29,9 +54,11 @@ const OurDepartmentsAverageHeightSurvey = () => {
       <ChooseFourBox isMulti items={OUR_DEPARTMENT_ITEMS} checkedMultiOption={checkedMultiOption} setMultiCheckedOption={setMultiCheckedOption}>
         학과를 선택해주세요
       </ChooseFourBox>
-      <HeightBox setHeightOption={setHeightOption}>평균 키를 알려주세요.</HeightBox>
+      <HeightBox heightOption={heightOption} setHeightOption={setHeightOption}>
+        평균 키를 알려주세요.
+      </HeightBox>
     </SurveyTemplate>
   );
 };
 
-export default OurDepartmentsAverageHeightSurvey;
+export default React.memo(OurDepartmentsAverageHeightSurvey);

--- a/src/pages/OurDepartmentsAverageHeightSurvey.tsx
+++ b/src/pages/OurDepartmentsAverageHeightSurvey.tsx
@@ -40,7 +40,7 @@ const OurDepartmentsAverageHeightSurvey = () => {
 
   return (
     <SurveyTemplate
-      disableNext={!checkedMultiOption && !heightOption}
+      disableNext={!checkedMultiOption || !heightOption}
       currStep={4}
       totalStep={14}
       handlePrevClick={() => meetingNavigate(Path.OurUniversitiesSurvey)}

--- a/src/pages/OurUniversitiesSurvey.tsx
+++ b/src/pages/OurUniversitiesSurvey.tsx
@@ -5,10 +5,22 @@ import SearchSelector from '@/components/domain/survey/SearchSelector';
 import { schools } from '@/mock/schools';
 import Path from '@/router/Path';
 import { useMeetingNavigate } from '@/hooks/common/useMeetingNavigate';
+import { useMeetingSessionState } from '@/hooks/common';
 
 const OurUniversitiesSurvey = () => {
   const meetingNavigate = useMeetingNavigate();
   const [ourUniversities, setOurUniversities] = useState<number[]>([]);
+  const { initMeetingState, setMeetingData } = useMeetingSessionState();
+
+  // @TODO: SearchSelector에서 id, name으로 구분하지 않고 상위에서 구분해야 함.
+  // selectedResults를 상위에서 받아서 초기화해야 하는데 문자열로 받아지게 되어 있음.
+  const handleNextClick = () => {
+    if (initMeetingState) {
+      setMeetingData({ ...initMeetingState, ourUniversities });
+    }
+
+    meetingNavigate(Path.OurDepartmentsAverageHeightSurvey);
+  };
 
   return (
     <SurveyTemplate
@@ -17,7 +29,7 @@ const OurUniversitiesSurvey = () => {
       totalStep={14}
       currStep={3}
       handlePrevClick={() => meetingNavigate(Path.GenderAverageAgeSurvey)}
-      handleNextClick={() => meetingNavigate(Path.OurDepartmentsAverageHeightSurvey)}
+      handleNextClick={handleNextClick}
     >
       <Title>
         <strong>참여자의 학교</strong>를<br />

--- a/src/pages/PlaySurvey.tsx
+++ b/src/pages/PlaySurvey.tsx
@@ -6,16 +6,25 @@ import styled from 'styled-components';
 import { PLAY_ITEMS } from '@/types/constants/play';
 import Path from '@/router/Path';
 import { useMeetingNavigate } from '@/hooks/common/useMeetingNavigate';
-
-export type ChoiceOptions = 'ALL' | 'GAME' | 'TALK';
+import { useMeetingSessionState } from '@/hooks/common';
+import { type Play } from '@/types/meeting';
 
 const PlaySurvey = () => {
   const meetingNavigate = useMeetingNavigate();
-  const [checkedOption, setCheckedOption] = useState<ChoiceOptions>('ALL');
+  const { initMeetingState, setMeetingData } = useMeetingSessionState();
+  const [checkedOption, setCheckedOption] = useState<Play>(initMeetingState.play);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { id } = e.target;
-    setCheckedOption(id as ChoiceOptions);
+    setCheckedOption(id as Play);
+  };
+
+  const handleNextClick = () => {
+    if (initMeetingState) {
+      setMeetingData({ ...initMeetingState, play: checkedOption });
+    }
+
+    meetingNavigate(Path.IsAbroadSurvey);
   };
 
   return (
@@ -24,7 +33,7 @@ const PlaySurvey = () => {
       currStep={10}
       totalStep={14}
       handlePrevClick={() => meetingNavigate(Path.MindsetSurvey)}
-      handleNextClick={() => meetingNavigate(Path.IsAbroadSurvey)}
+      handleNextClick={handleNextClick}
     >
       <Title>
         <strong>술게임 여부</strong>를

--- a/src/pages/PreferAverageAgeHeightSurvey.tsx
+++ b/src/pages/PreferAverageAgeHeightSurvey.tsx
@@ -3,18 +3,26 @@ import { SurveyTemplate } from '@/components/domain/survey';
 import { AgeBox, HeightBox } from '@/components/domain/survey';
 import { Title } from '@/lib/styles/styledComponents';
 import styled from 'styled-components';
-import { MIN_AGE, MAX_AGE } from '@/components/domain/survey/AgeBox';
-import { MIN_HEIGHT, MAX_HEIGHT } from '@/components/domain/survey/HeightBox';
 import { useMatch } from 'react-router-dom';
 import { useDatingNavigate, useMeetingNavigate } from '@/hooks/common/useMeetingNavigate';
+import { useMeetingSessionState } from '@/hooks/common';
 import Path from '@/router/Path';
 
 const PreferAverageAgeHeightSurvey = () => {
   const matchMeeting = useMatch('/meeting/*');
   const meetingNavigate = matchMeeting ? useMeetingNavigate() : useDatingNavigate();
 
-  const [multiAgeOption, setMultiAgeOption] = useState<number[]>([MIN_AGE, MAX_AGE]);
-  const [multiHeightOption, setMultiHeightOption] = useState<number[]>([MIN_HEIGHT, MAX_HEIGHT]);
+  const { initMeetingState, setMeetingData } = useMeetingSessionState();
+  const [multiAgeOption, setMultiAgeOption] = useState<number[]>(initMeetingState.preferAge);
+  const [multiHeightOption, setMultiHeightOption] = useState<number[]>(initMeetingState.preferHeight);
+
+  const handleNextClick = () => {
+    if (initMeetingState) {
+      setMeetingData({ ...initMeetingState, preferAge: multiAgeOption, preferHeight: multiHeightOption });
+    }
+
+    meetingNavigate(matchMeeting ? Path.MindsetSurvey : Path.PreferDepartmentCharacterSurvey);
+  };
 
   return (
     <SurveyTemplate
@@ -22,16 +30,16 @@ const PreferAverageAgeHeightSurvey = () => {
       totalStep={matchMeeting ? 14 : 12}
       currStep={matchMeeting ? 8 : 9}
       handlePrevClick={() => meetingNavigate(matchMeeting ? Path.PreferDepartmentsSurvey : Path.PreferUniversitiesSurvey)}
-      handleNextClick={() => meetingNavigate(matchMeeting ? Path.MindsetSurvey : Path.PreferDepartmentCharacterSurvey)}
+      handleNextClick={handleNextClick}
     >
       <StyledTitle>
         <strong>선호하는 범위를</strong>
         <br /> 최대한 넓게 알려주세요.
       </StyledTitle>
-      <AgeBox setMultiAgeOption={setMultiAgeOption} isMulti>
+      <AgeBox multiAgeOption={multiAgeOption} setMultiAgeOption={setMultiAgeOption} isMulti>
         나이를 알려주세요.
       </AgeBox>
-      <HeightBox setMultiHeightOption={setMultiHeightOption} isMulti>
+      <HeightBox multiHeightOption={multiHeightOption} setMultiHeightOption={setMultiHeightOption} isMulti>
         키를 알려주세요.
       </HeightBox>
     </SurveyTemplate>

--- a/src/pages/TypeOfMeetingSurvey.tsx
+++ b/src/pages/TypeOfMeetingSurvey.tsx
@@ -16,10 +16,11 @@ const TypeOfMeetingSurvey = () => {
   const [checkedOption, setCheckedOption] = useState<Meeting['typeOfMeeting'] | string>(initMeetingState?.typeOfMeeting);
 
   const handleNextClick = () => {
-    meetingNavigate(Path.GenderAverageAgeSurvey);
     if (initMeetingState) {
       setMeetingData({ ...initMeetingState, typeOfMeeting: checkedOption as Meeting['typeOfMeeting'] });
     }
+
+    meetingNavigate(Path.GenderAverageAgeSurvey);
   };
 
   return (

--- a/src/pages/TypeOfMeetingSurvey.tsx
+++ b/src/pages/TypeOfMeetingSurvey.tsx
@@ -5,21 +5,21 @@ import { ChooseFourBox } from '@/components/domain/survey';
 import { useMeetingNavigate } from '@/hooks/common/useMeetingNavigate';
 import Path from '@/router/Path';
 import { useNavigate } from 'react-router-dom';
-import { useMeetingState } from '@/atoms/meetingState';
 import { type Meeting } from '@/types/meeting';
 import { TYPE_OF_MEETING_ITEMS } from '@/types/constants/constant';
-
-export type ChoiceOptions = 'ONE' | 'TWO' | 'THREE' | 'FOUR';
+import { useMeetingSessionState } from '@/hooks/common';
 
 const TypeOfMeetingSurvey = () => {
   const navigate = useNavigate();
   const meetingNavigate = useMeetingNavigate();
-  const [checkedOption, setCheckedOption] = useState<Meeting['typeOfMeeting'] | string>('ONE');
-  const { meetingData, setMeetingData } = useMeetingState();
+  const { initMeetingState, setMeetingData } = useMeetingSessionState();
+  const [checkedOption, setCheckedOption] = useState<Meeting['typeOfMeeting'] | string>(initMeetingState?.typeOfMeeting);
 
   const handleNextClick = () => {
     meetingNavigate(Path.GenderAverageAgeSurvey);
-    setMeetingData({ ...meetingData, typeOfMeeting: checkedOption as Meeting['typeOfMeeting'] });
+    if (initMeetingState) {
+      setMeetingData({ ...initMeetingState, typeOfMeeting: checkedOption as Meeting['typeOfMeeting'] });
+    }
   };
 
   return (

--- a/src/types/constants/constant.ts
+++ b/src/types/constants/constant.ts
@@ -23,12 +23,12 @@ export const TYPE_OF_MEETING_ITEMS = [
 
 export const GENDER_ITEMS = [
   {
-    id: 'FEMAIL',
+    id: 'FEMALE',
     text: '여자',
     name: 'gender',
   },
   {
-    id: 'MAIL',
+    id: 'MALE',
     text: '남자',
     name: 'gender',
   },

--- a/src/types/constants/department.ts
+++ b/src/types/constants/department.ts
@@ -1,3 +1,5 @@
+import { ChooseFourDepartmentProps } from '@/pages/OurDepartmentsAverageHeightSurvey';
+
 export const MY_DEPARTMENT_ITEMS = [
   {
     id: 'LIBERAL',
@@ -21,7 +23,7 @@ export const MY_DEPARTMENT_ITEMS = [
   },
 ];
 
-export const OUR_DEPARTMENT_ITEMS = [
+export const OUR_DEPARTMENT_ITEMS: ChooseFourDepartmentProps[] = [
   {
     id: 'LIBERAL',
     text: '문과',

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1,4 +1,0 @@
-export enum Abroad {
-  domestic = 'domestic',
-  abroad = 'abroad',
-}

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -3,6 +3,7 @@ export type TypeOfMeeting = 'ONE' | 'TWO' | 'THREE' | 'FOUR';
 export type Departments = 'LIBERAL' | 'SCIENCE' | 'ART' | 'ATHLETIC';
 export type MindSet = 'ALL' | 'FRIEND' | 'LOVE';
 export type Play = 'ALL' | 'GAME' | 'TALK';
+export type Location = 'ABROAD' | 'DOMESTIC';
 export type DomesticAreas = 'ICN' | 'SNW' | 'SNE' | 'SSW' | 'SSE' | 'GN' | 'GS';
 export type Channel = 'FACEBOOK' | 'INSTAGRAM' | 'KAKAOROOM' | 'KAKAOPLUS' | 'FRIEND' | 'COMMUNITY';
 

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -12,7 +12,7 @@ export interface Meeting {
   averageAge: number;
   ourUniversities: number[];
   ourDepartments: Departments[];
-  averageHeight: number[];
+  averageHeight: number; // @FIXME: number[] -> number
   avoidUniversities: number[];
   preferUniversities: number[];
   preferAge: number[];


### PR DESCRIPTION
## 🧑‍💻 PR 내용
- Closes #93 
<!-- 수정/추가한 내용을 적어주세요. -->

### 미적용
- 소개팅 설문 전체 [ ]
- our-univ [ ]
- avoid-univ [ ]
- prefer-univ [ ]
- abroad-area [ ]

## 📸 스크린샷

<!-- 스크린샷을 첨부해주세요. -->

## 🧐 논의할 점
- 검색 관련 설문들이 atom에 저장될 때 number[] 형태인데,
세션 값을 가져와서 보여주기 위해서는 `{id, name}` 형태로 상위에서 저장하고 사용해야 함.
현재는 하위 SearchSelector 에서만 아이템을 객체 형태로 받고 있음.
SearchSelector는 props로 selectedResults를 받도록 구현되어 있었는데 얘의 초기값으로 세션에 저장된 값을 넘겨주면 해결됨.
문제는 selectedResults가 string[] 형태로 받도록 되어있어서 얘 타입 바꾸면 로직 다 바꿔야 함.
건들기가 쉽지 않아서 @choisohyun 님이 이 부분 해주셔야 될 거 같아요 ㅜ 

```tsx
  const [selectedSchools, setSelectedSchools] = useState<string[]>([]); // 렌더링될 NAME 데이터

```
<!-- 논의할 내용을 적어주세요. -->
