### PR TITLE
fix: SearchSelector 세션스토리지 있을 경우 값 유지되도록 변경

### DIFF
--- a/src/components/domain/survey/SearchSelector.tsx
+++ b/src/components/domain/survey/SearchSelector.tsx
@@ -47,10 +47,16 @@ const SearchSelector = ({ placeholder, searchData, selectedResults, setSelectedR
     setSelectedResults((prev) => prev.filter((id) => id !== findId(value)));
   };
 
+  const resetClick = () => {
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+  };
+
   return (
     <>
       <SearchWrapper>
-        <SearchInput ref={inputRef} list="schools" placeholder={placeholder} onChange={handleInputChange} />
+        <SearchInput ref={inputRef} list="schools" placeholder={placeholder} onChange={handleInputChange} onClick={resetClick} />
         <datalist id="schools">
           {searchData.map(({ name, id }) => (
             <option key={id} value={name} />

--- a/src/components/domain/survey/SearchSelector.tsx
+++ b/src/components/domain/survey/SearchSelector.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useCallback, useRef, useState } from 'react';
+import React, { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { DeleteIcon, SearchIcon } from '@/assets/img';
 
@@ -22,6 +22,12 @@ const SearchSelector = ({ placeholder, searchData, selectedResults, setSelectedR
   const [selectedSchools, setSelectedSchools] = useState<string[]>([]); // 렌더링될 NAME 데이터
 
   const findId = useCallback((value: string) => Number(searchData.find((data) => data.name === value)?.id), [searchData]);
+
+  useEffect(() => {
+    selectedResults.map((id) => {
+      setSelectedSchools(() => searchData.filter((name) => name.id === id).map(({ name }) => name));
+    });
+  }, []);
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;

--- a/src/components/domain/survey/SearchSelector.tsx
+++ b/src/components/domain/survey/SearchSelector.tsx
@@ -24,9 +24,8 @@ const SearchSelector = ({ placeholder, searchData, selectedResults, setSelectedR
   const findId = useCallback((value: string) => Number(searchData.find((data) => data.name === value)?.id), [searchData]);
 
   useEffect(() => {
-    selectedResults.map((id) => {
-      setSelectedSchools(() => searchData.filter((name) => name.id === id).map(({ name }) => name));
-    });
+    const result = selectedResults.flatMap((id) => searchData.filter((item) => item.id === id)).map(({ name }) => name);
+    setSelectedSchools(result);
   }, []);
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/components/domain/survey/SearchSelector.tsx
+++ b/src/components/domain/survey/SearchSelector.tsx
@@ -34,12 +34,12 @@ const SearchSelector = ({ placeholder, searchData, selectedResults, setSelectedR
     const id = findId(value);
 
     const noMatchData = !searchData.map(({ id }) => id).includes(id);
+    const existSelected = selectedResults.includes(id);
     const overMaxLimit = selectedResults.length >= MAX;
-    if (noMatchData || overMaxLimit) return;
+    if (noMatchData || existSelected || overMaxLimit) return;
 
     setSelectedResults((prev) => [...prev, id]);
     setSelectedSchools((prev) => [...prev, value]);
-    console.log(selectedResults);
   };
 
   const handleDeleteClick = (value: string) => {

--- a/src/pages/OurUniversitiesSurvey.tsx
+++ b/src/pages/OurUniversitiesSurvey.tsx
@@ -9,11 +9,9 @@ import { useMeetingSessionState } from '@/hooks/common';
 
 const OurUniversitiesSurvey = () => {
   const meetingNavigate = useMeetingNavigate();
-  const [ourUniversities, setOurUniversities] = useState<number[]>([]);
   const { initMeetingState, setMeetingData } = useMeetingSessionState();
+  const [ourUniversities, setOurUniversities] = useState<number[]>(initMeetingState.ourUniversities);
 
-  // @TODO: SearchSelector에서 id, name으로 구분하지 않고 상위에서 구분해야 함.
-  // selectedResults를 상위에서 받아서 초기화해야 하는데 문자열로 받아지게 되어 있음.
   const handleNextClick = () => {
     if (initMeetingState) {
       setMeetingData({ ...initMeetingState, ourUniversities });


### PR DESCRIPTION
## 🧑‍💻 PR 내용

<!-- 수정/추가한 내용을 적어주세요. -->
우선 원래 있던 SearchSelector에 useEffect에서 필터시키는 방식으로 적용해 보았습니다

원래 의도는 SearchSelector에서는 string[], 부모 컴포넌트에서는 number[](api넘길때 number만 필요)만 알고있게 하기위함이었는데 컴포넌트 복잡도가 좀 올라간것 같네요 ㅎㅎ;;



## 📸 스크린샷

<!-- 스크린샷을 첨부해주세요. -->
<img width="1159" alt="Screen Shot 2022-06-25 at 22 35 25" src="https://user-images.githubusercontent.com/30427711/175775897-05c12aad-9482-4f3b-8087-02a2561b5554.png">

## 🧐 논의할 점

<!-- 논의할 내용을 적어주세요. -->
이후에 밑에 둘중에 하나 방식으로 변경사항 적게 리팩토링할까 합니다..! 
1. name, id 객체를 가지고 name, id 각각 컴포넌트에서 사용가능하도록 훅을 만들기
2. recoil selector 활용하기